### PR TITLE
fix: Safari extension network and auth errors

### DIFF
--- a/ios/CoolectionSafari/CoolectionSafari Extension/Resources/manifest.json
+++ b/ios/CoolectionSafari/CoolectionSafari Extension/Resources/manifest.json
@@ -4,6 +4,7 @@
   "version": "1.0",
   "description": "Save the current page to Coolection",
   "permissions": ["nativeMessaging", "activeTab", "scripting"],
+  "host_permissions": ["https://*/*"],
   "action": {
     "default_icon": {
       "48": "images/icon-48.png",

--- a/middleware.ts
+++ b/middleware.ts
@@ -14,6 +14,12 @@ const isProtectedRoute = createRouteMatcher([
 // See: https://clerk.com/docs/references/nextjs/clerk-middleware
 export default clerkMiddleware(
   (auth: ClerkMiddlewareAuth, req: NextRequest) => {
+    // Skip Clerk auth for requests using API token auth
+    const authorization = req.headers.get("authorization");
+    if (authorization?.startsWith("Bearer coolection_")) {
+      return NextResponse.next();
+    }
+
     const homeUrl = new URL("/home", req.url);
 
     // Redirect to /home if user is signed in


### PR DESCRIPTION
## Summary
- Add `host_permissions` to the Safari extension manifest so the background service worker can make fetch requests to the Coolection API
- Skip Clerk middleware for requests carrying a `coolection_` Bearer token so Clerk doesn't intercept and reject API token auth

## Test plan
- [ ] Build and run the extension on device
- [ ] Tap the extension icon in Safari — should show "Saved to Coolection" instead of "Network error" or "Failed to save (401)"
- [ ] Verify Clerk session auth still works for the web app

🤖 Generated with [Claude Code](https://claude.com/claude-code)