### PR TITLE
feat: Chrome extension + multi-token API key management

### DIFF
--- a/app/api/token/[id]/route.ts
+++ b/app/api/token/[id]/route.ts
@@ -1,0 +1,57 @@
+import { auth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+import prisma from "@/lib/prisma";
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  const { userId } = auth();
+
+  if (!userId) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const { count } = await prisma.apiToken.deleteMany({
+    where: { id: params.id, userId },
+  });
+
+  if (count === 0) {
+    return NextResponse.json({ message: "Token not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ message: "Token revoked" });
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  const { userId } = auth();
+
+  if (!userId) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  let name = "";
+  try {
+    const body = await req.json();
+    if (typeof body.name === "string") {
+      name = body.name.trim().slice(0, 64);
+    }
+  } catch {
+    return NextResponse.json({ message: "Invalid body" }, { status: 400 });
+  }
+
+  const { count } = await prisma.apiToken.updateMany({
+    where: { id: params.id, userId },
+    data: { name },
+  });
+
+  if (count === 0) {
+    return NextResponse.json({ message: "Token not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ id: params.id, name });
+}

--- a/app/api/token/generate/route.ts
+++ b/app/api/token/generate/route.ts
@@ -4,11 +4,23 @@ import { NextResponse } from "next/server";
 
 import prisma from "@/lib/prisma";
 
-export async function POST() {
+const MAX_TOKENS = 5;
+
+export async function POST(req: Request) {
   const { userId } = auth();
 
   if (!userId) {
     return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  let name = "";
+  try {
+    const body = await req.json();
+    if (typeof body.name === "string") {
+      name = body.name.trim().slice(0, 64);
+    }
+  } catch {
+    // No body or invalid JSON — name stays ""
   }
 
   const raw = crypto.randomBytes(32).toString("base64url");
@@ -17,7 +29,8 @@ export async function POST() {
 
   try {
     const user = await currentUser();
-    await prisma.$transaction(async (tx) => {
+
+    const id = await prisma.$transaction(async (tx) => {
       await tx.user.upsert({
         where: { id: userId },
         update: {},
@@ -30,15 +43,25 @@ export async function POST() {
         },
       });
 
-      await tx.apiToken.upsert({
-        where: { userId },
-        update: { tokenHash },
-        create: { userId, tokenHash },
+      const count = await tx.apiToken.count({ where: { userId } });
+      if (count >= MAX_TOKENS) {
+        throw new Error("TOKEN_LIMIT");
+      }
+
+      const created = await tx.apiToken.create({
+        data: { userId, tokenHash, name },
       });
+      return created.id;
     });
 
-    return NextResponse.json({ token });
+    return NextResponse.json({ token, id, name });
   } catch (error) {
+    if (error instanceof Error && error.message === "TOKEN_LIMIT") {
+      return NextResponse.json(
+        { message: `Token limit reached (max ${MAX_TOKENS})` },
+        { status: 409 },
+      );
+    }
     return NextResponse.json(
       {
         message: "Failed to generate token",

--- a/app/api/token/list/route.ts
+++ b/app/api/token/list/route.ts
@@ -1,0 +1,31 @@
+import { auth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+import prisma from "@/lib/prisma";
+
+export async function GET() {
+  const { userId } = auth();
+
+  if (!userId) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const tokens = await prisma.apiToken.findMany({
+    where: { userId },
+    select: {
+      id: true,
+      name: true,
+      tokenHash: true,
+      createdAt: true,
+      lastUsedAt: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json({
+    tokens: tokens.map(({ tokenHash, ...rest }) => ({
+      ...rest,
+      tokenPrefix: tokenHash.slice(0, 4),
+    })),
+  });
+}

--- a/docs/solutions/logic-errors/race-conditions-chrome-mv3-extension.md
+++ b/docs/solutions/logic-errors/race-conditions-chrome-mv3-extension.md
@@ -1,0 +1,177 @@
+---
+title: Chrome MV3 Extension Race Conditions in Service Worker and Options Page
+category: logic-errors
+tags: [race-condition, chrome-extension, mv3, service-worker, timeout-management, concurrent-requests, event-driven-architecture]
+module: chrome-extension
+symptom: "Double-clicking toolbar icon causes duplicate API requests and interleaved toasts; fetch hangs forever with stuck Saving... toast; new toast removed by stale fade-out timer; options form saves empty values before storage loads; success auto-clear erases subsequent error message"
+root_cause: "Missing concurrency guards, no fetch timeout, untracked nested timeouts, unsynchronized form submission with async storage load, uncleared status timeout across invocations"
+date_solved: "2026-02-07"
+severity: P1
+---
+
+# Chrome MV3 Extension Race Conditions
+
+## Problem
+
+After building the Chrome MV3 extension, a multi-agent code review identified 5 race conditions across `background.js` (service worker) and `options.js` (settings page):
+
+1. **Double-click concurrent saves (P1)** — Clicking the toolbar icon or context menu rapidly triggered overlapping `saveUrl()` calls, causing duplicate API requests and interleaved toast messages.
+2. **Missing fetch timeout (P1)** — `fetch()` had no timeout. If the server hung, the "Saving..." toast stayed forever and the extension appeared frozen.
+3. **Untracked inner toast timeout (P2)** — `showToast()` tracked `_coolectionTimeout` (fade delay) but not the inner `setTimeout(() => t.remove(), 200)`. A new toast appearing during the 200ms fade-out window would be deleted by the stale timer.
+4. **Form submit before storage loads (P2)** — The options form could be submitted before `chrome.storage.local.get()` finished, saving empty/default values over actual settings.
+5. **Status timeout collision (P2)** — `showStatus()` success auto-clear (3s) wasn't tracked. A quick save → validation error sequence would have the stale success timeout clear the error after 3s.
+
+## Root Cause
+
+Chrome MV3 service workers are event-driven and non-persistent. All event handlers are registered synchronously at the top level, but the handler bodies are async. Nothing prevents multiple user actions from triggering overlapping async operations. The original code assumed sequential execution that the architecture doesn't guarantee.
+
+## Solution
+
+### Fix 1: Double-click guard — `background.js`
+
+```javascript
+// Before: no guard, concurrent calls proceed freely
+async function saveUrl(tabId, url) {
+  if (!url || !/^https?:\/\//.test(url)) return;
+  // ... immediately proceeds to fetch
+}
+
+// After: module-level flag prevents concurrent saves
+let saving = false;
+async function saveUrl(tabId, url) {
+  if (!url || !/^https?:\/\//.test(url)) return;
+  if (saving) return;
+
+  saving = true;
+  try {
+    // ... fetch and handle response ...
+  } finally {
+    saving = false;
+  }
+}
+```
+
+### Fix 2: Fetch timeout with AbortController — `background.js`
+
+```javascript
+// Before: bare fetch(), hangs indefinitely
+const response = await fetch(url, { method: "POST", ... });
+
+// After: 10s timeout via AbortController
+const controller = new AbortController();
+const timeout = setTimeout(() => controller.abort(), 10000);
+
+try {
+  const response = await fetch(url, {
+    method: "POST",
+    signal: controller.signal,
+    // ...
+  });
+  // ... handle response ...
+} catch (e) {
+  if (e.name === "AbortError") {
+    showToast(tabId, "Request timed out — try again");
+  } else {
+    showToast(tabId, "Network error — check connection");
+  }
+} finally {
+  clearTimeout(timeout);
+  saving = false;
+}
+```
+
+### Fix 3: Track inner remove timeout — `background.js`
+
+```javascript
+// Before: only _coolectionTimeout tracked
+if (t) {
+  clearTimeout(t._coolectionTimeout);
+  // inner remove timeout not cleared — can delete new toast
+}
+
+// After: both timeouts tracked and cleared
+if (t) {
+  clearTimeout(t._coolectionTimeout);
+  clearTimeout(t._coolectionRemoveTimeout);
+}
+// ...
+t._coolectionTimeout = setTimeout(() => {
+  t.style.opacity = "0";
+  t._coolectionRemoveTimeout = setTimeout(() => t.remove(), 200);
+}, 2000);
+```
+
+### Fix 4: Loaded guard for options form — `options.js`
+
+```javascript
+// Before: submit handler runs immediately, storage may not be loaded
+document.getElementById("form").addEventListener("submit", async (e) => {
+  e.preventDefault();
+  // could save empty values if storage hasn't loaded yet
+});
+
+// After: flag set after storage loads, checked before save
+let loaded = false;
+
+document.addEventListener("DOMContentLoaded", async () => {
+  const { token, serverUrl } = await chrome.storage.local.get([...]);
+  // ... populate form ...
+  loaded = true;
+});
+
+document.getElementById("form").addEventListener("submit", async (e) => {
+  e.preventDefault();
+  if (!loaded) return;
+  // ... safe to save ...
+});
+```
+
+### Fix 5: Track status timeout — `options.js`
+
+```javascript
+// Before: timeout not tracked, stale success clear erases error
+function showStatus(message, type) {
+  el.textContent = message;
+  if (type === "success") {
+    setTimeout(() => { el.textContent = ""; }, 3000); // untracked
+  }
+}
+
+// After: clear previous timeout on each call
+let statusTimeout;
+function showStatus(message, type) {
+  clearTimeout(statusTimeout);
+  el.textContent = message;
+  if (type === "success") {
+    statusTimeout = setTimeout(() => { el.textContent = ""; }, 3000);
+  }
+}
+```
+
+## Prevention
+
+### Code Review Checklist for Extension Code
+
+- [ ] All async event handlers have a guard flag to prevent concurrent invocations
+- [ ] All `fetch()` calls use `AbortController` with an explicit timeout
+- [ ] Every `setTimeout` return value is stored and cleared on reuse or teardown
+- [ ] Nested timeouts (e.g., fade then remove) are individually tracked
+- [ ] Form submit handlers verify async initialization is complete before proceeding
+- [ ] Auto-clearing UI feedback (success messages, toasts) tracks its timeout ID and clears on each call
+- [ ] `finally` blocks reset all guard flags and clean up timers
+
+### General Principles
+
+- **Every timeout needs a name.** If you can't `clearTimeout(x)` on it, it's a bug waiting to happen.
+- **Guard async entry points.** Service worker event handlers can fire concurrently — assume they will.
+- **Always reach a terminal state.** Use `finally` to ensure flags reset and timers clear, even on errors.
+- **Don't trust timing.** A "3 second auto-clear" and a "user clicks again in 2 seconds" will overlap. Design for it.
+
+## Related Documentation
+
+- `docs/plans/2026-02-07-feat-chrome-extension-plan.md` — Original implementation plan with toast and timeout patterns
+- `docs/brainstorms/2026-02-07-chrome-extension-brainstorm.md` — Initial architecture exploration
+- `ios/CoolectionSafari/CoolectionSafari Extension/Resources/background.js` — Safari extension with similar toast pattern (same class of bugs may apply)
+- `docs/plans/2026-02-06-feat-safari-extension-ios-plan.md` — Safari plan noting service worker death after 30-45s on iOS
+
+This is the first entry in `docs/solutions/`. The Safari extension's `background.js` uses the same toast reuse pattern and should be audited for the same inner-timeout tracking issue (Fix 3).

--- a/lib/resolve-user-id.ts
+++ b/lib/resolve-user-id.ts
@@ -12,9 +12,15 @@ export async function resolveUserId(): Promise<string | null> {
     const tokenHash = crypto.createHash("sha256").update(token).digest("hex");
     const apiToken = await prisma.apiToken.findUnique({
       where: { tokenHash },
-      select: { userId: true },
+      select: { id: true, userId: true },
     });
-    return apiToken?.userId ?? null;
+    if (apiToken) {
+      prisma.apiToken
+        .update({ where: { id: apiToken.id }, data: { lastUsedAt: new Date() } })
+        .catch(() => {});
+      return apiToken.userId;
+    }
+    return null;
   }
 
   return auth().userId;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,18 +19,21 @@ model User {
   updatedAt DateTime  @updatedAt
   items     Item[]
   lists     List[]
-  apiToken  ApiToken?
+  apiTokens ApiToken[]
 
   @@map("user")
 }
 
 model ApiToken {
-  id        String   @id @default(uuid())
-  userId    String   @unique
-  tokenHash String   @unique
-  createdAt DateTime @default(now())
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id         String    @id @default(uuid())
+  userId     String
+  tokenHash  String    @unique
+  name       String    @default("")
+  lastUsedAt DateTime?
+  createdAt  DateTime  @default(now())
+  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  @@index([userId])
   @@map("api_token")
 }
 


### PR DESCRIPTION
## Summary

- **Chrome MV3 extension** for saving pages to Coolection via toolbar icon or right-click context menu
- **Multi-token API key management** so multiple devices/extensions can authenticate independently (Safari iPhone + Chrome Desktop without invalidating each other)
- **Race condition fixes** identified by multi-agent code review (concurrent save guard, fetch timeout, toast timer tracking)

## What's included

### Chrome Extension (`chrome-extension/`)
- Manifest V3 with service worker, context menu, and toolbar action
- Options page for configuring API token and server URL (self-hosting supported)
- Toast injection for save feedback on the active tab
- Icons (16/48/128px)

### Multi-Token Management
- Schema migration: multiple tokens per user with `name` and `lastUsedAt` fields
- `POST /api/token/generate` — creates named tokens (max 5 per user)
- `GET /api/token/list` — lists all tokens with metadata
- `DELETE /api/token/[id]` — revokes individual tokens
- `PATCH /api/token/[id]` — renames tokens
- `lastUsedAt` updated on each token-authenticated API call (fire-and-forget)
- Settings page redesigned with token list, create flow, and per-token revoke

### Race Condition Fixes
- Saving guard prevents concurrent double-click saves
- AbortController with 10s timeout prevents stuck "Saving..." toast
- Inner remove-timeout tracked to prevent new toast deletion during fade-out
- Options form guarded against submit before storage loads
- Status timeout tracked to prevent stale auto-clear erasing errors

## Test plan

- [ ] Load Chrome extension via `chrome://extensions` → Load unpacked → select `chrome-extension/`
- [ ] Configure token and server URL in extension options
- [ ] Save a page via toolbar icon and context menu
- [ ] Generate multiple named tokens at `/settings`
- [ ] Verify both tokens work simultaneously from different extensions
- [ ] Revoke a token and confirm it returns 401
- [ ] Verify 5-token limit with clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)