### PR TITLE
fix: replace hardcoded black toast bg with frosted glass blur

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -98,7 +98,7 @@ function showToast(tabId, message, persistent) {
         t.textContent = msg;
         t.style.cssText =
           "position:fixed;bottom:24px;left:50%;transform:translateX(-50%);" +
-          "background:#000;color:#fff;padding:10px 20px;border-radius:8px;" +
+          "background:rgba(0,0,0,0.55);-webkit-backdrop-filter:blur(12px);backdrop-filter:blur(12px);color:#fff;padding:10px 20px;border-radius:8px;" +
           "font:14px Inter,-apple-system,system-ui,sans-serif;z-index:2147483647;" +
           "opacity:0;transition:opacity .2s";
         document.body.appendChild(t);

--- a/ios/CoolectionSafari/CoolectionSafari Extension/Resources/background.js
+++ b/ios/CoolectionSafari/CoolectionSafari Extension/Resources/background.js
@@ -9,7 +9,7 @@ function showToast(tabId, message, persistent) {
         t = document.createElement("div");
         t.id = "coolection-toast";
         t.textContent = msg;
-        t.style.cssText = "position:fixed;bottom:24px;left:50%;transform:translateX(-50%);background:#000;color:#fff;padding:10px 20px;border-radius:8px;font:14px -apple-system,sans-serif;z-index:2147483647;opacity:0;transition:opacity .2s";
+        t.style.cssText = "position:fixed;bottom:24px;left:50%;transform:translateX(-50%);background:rgba(0,0,0,0.55);-webkit-backdrop-filter:blur(12px);backdrop-filter:blur(12px);color:#fff;padding:10px 20px;border-radius:8px;font:14px -apple-system,sans-serif;z-index:2147483647;opacity:0;transition:opacity .2s";
         document.body.appendChild(t);
         requestAnimationFrame(() => (t.style.opacity = "1"));
       }


### PR DESCRIPTION
## Summary
- Toast background was hardcoded `#000`, invisible on dark-themed websites
- Replaced with frosted glass: `rgba(0,0,0,0.55)` + `backdrop-filter:blur(12px)`
- Includes `-webkit-backdrop-filter` prefix for Safari compatibility
- Both Chrome and Safari extensions updated

## Test plan
- [ ] Load Chrome extension, save a bookmark on a light-bg site (e.g., google.com) — toast visible with blur
- [ ] Save on a dark-bg site (e.g., GitHub dark mode) — toast visible, not blending in
- [ ] Load Safari extension on iOS, repeat both checks
- [ ] Verify toast position, fade animation, and auto-dismiss unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)