### PR TITLE
feat: add PrivacyInfo.xcprivacy to iOS app and extension targets

### DIFF
--- a/ios/CoolectionSafari/CoolectionSafari Extension/PrivacyInfo.xcprivacy
+++ b/ios/CoolectionSafari/CoolectionSafari Extension/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ios/CoolectionSafari/CoolectionSafari.xcodeproj/project.pbxproj
+++ b/ios/CoolectionSafari/CoolectionSafari.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		C00000052F380000003CF7DD /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00000032F380000003CF7DD /* KeychainHelper.swift */; };
 		C00000072F380000003CF7DD /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00000092F380000003CF7DD /* Constants.swift */; };
 		C00000082F380000003CF7DD /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00000092F380000003CF7DD /* Constants.swift */; };
+		D00000012F400000003CF7DD /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D00000032F400000003CF7DD /* PrivacyInfo.xcprivacy */; };
+		D00000022F400000003CF7DD /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D00000042F400000003CF7DD /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,6 +79,8 @@
 		C00000092F380000003CF7DD /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = Shared/Constants.swift; sourceTree = "<group>"; };
 		C0000A032F380000003CF7DD /* Inter-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Inter-Regular.ttf"; sourceTree = "<group>"; };
 		C0000A042F380000003CF7DD /* Inter-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Inter-Medium.ttf"; sourceTree = "<group>"; };
+		D00000032F400000003CF7DD /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		D00000042F400000003CF7DD /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -127,6 +131,7 @@
 				B33754E22F37BD39003CF7DD /* Main.storyboard */,
 				B33754E52F37BD3A003CF7DD /* Assets.xcassets */,
 				B33754E62F37BD3A003CF7DD /* Info.plist */,
+				D00000032F400000003CF7DD /* PrivacyInfo.xcprivacy */,
 				C0000A052F380000003CF7DD /* Fonts */,
 				B33754D32F37BD39003CF7DD /* Resources */,
 			);
@@ -149,6 +154,7 @@
 				B33754FD2F37BD3A003CF7DD /* Resources */,
 				B33754F02F37BD3A003CF7DD /* SafariWebExtensionHandler.swift */,
 				B33754F22F37BD3A003CF7DD /* Info.plist */,
+				D00000042F400000003CF7DD /* PrivacyInfo.xcprivacy */,
 			);
 			path = "CoolectionSafari Extension";
 			sourceTree = "<group>";
@@ -276,6 +282,7 @@
 				B33754D62F37BD39003CF7DD /* Main.html in Resources */,
 				B33754F32F37BD3A003CF7DD /* Assets.xcassets in Resources */,
 				B33754DA2F37BD39003CF7DD /* Style.css in Resources */,
+				D00000012F400000003CF7DD /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -286,6 +293,7 @@
 				B33755022F37BD3A003CF7DD /* images in Resources */,
 				B33755032F37BD3A003CF7DD /* manifest.json in Resources */,
 				B33755012F37BD3A003CF7DD /* background.js in Resources */,
+				D00000022F400000003CF7DD /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/CoolectionSafari/CoolectionSafari/PrivacyInfo.xcprivacy
+++ b/ios/CoolectionSafari/CoolectionSafari/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds `PrivacyInfo.xcprivacy` to both the CoolectionSafari app and extension targets
- Required for App Store submission — without it, Apple rejects with ITMS-91053
- Declares `UserDefaults` (reason `1C8F.1`) as the only required reason API, used to share server URL between app and extension via App Group

## Test plan
- [ ] Open project in Xcode — verify `PrivacyInfo.xcprivacy` appears under both CoolectionSafari and CoolectionSafari Extension in the navigator
- [ ] Build both targets — no errors
- [ ] Check each target's Build Phases > Copy Bundle Resources includes the privacy manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)