### PR TITLE
fix: Update the url of View setup instructions on GitHub (#27)

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -398,7 +398,7 @@ export default function SettingsPage() {
               <li>Bookmarks will appear in your <span className="font-medium">X Bookmarks</span> list</li>
             </ol>
             <a
-              href="https://github.com/kasper-gb/coolection"
+              href="https://github.com/lovincyrus/coolection"
               target="_blank"
               rel="noreferrer noopener"
               className="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-900"


### PR DESCRIPTION
Fixes #27

## Summary

Automated changes for: **Update the url of View setup instructions on GitHub**

## Issue Description

Use the correct URL https://github.com/lovincyrus/coolection

## Changes

```
aaea11e fix: update GitHub setup instructions URL to correct repo
5900742 fix: Create GitHub Stars and X Bookmarks List (#22) (#23)
1383d4f fix: Replace matcha icon with the new icon (#25) (#26)
```

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) Generated with [Claude Code](https://claude.com/claude-code)