### PR TITLE
fix: Remove lag experience when opening a never-been-loaded before list (#32)

### DIFF
--- a/app/components/list-results.tsx
+++ b/app/components/list-results.tsx
@@ -15,11 +15,9 @@ import { ResultItemSkeletons } from "./result-item-skeletons";
 export function ListResults({
   listId,
   listsServerData,
-  listItemsServerData,
 }: {
   listId: string;
   listsServerData: any;
-  listItemsServerData?: any;
 }) {
   const isInList = useIsInList();
   const { data: lists } = useLists(listsServerData);
@@ -27,11 +25,12 @@ export function ListResults({
     data: itemsFromList,
     loading,
     mutate: mutateItemsFromList,
-  } = useItemsFromList(listId, listItemsServerData);
+  } = useItemsFromList(listId);
 
-  const showSkeleton = useLoadingWithTimeout(loading, 100);
+  const hasItems = Array.isArray(itemsFromList) && itemsFromList.length > 0;
+
   const showEmptyListItemsCopy = useLoadingWithTimeout(
-    isInList && Object.keys(itemsFromList).length === 0 && !loading,
+    isInList && !hasItems && !loading,
     300,
   );
 
@@ -55,11 +54,10 @@ export function ListResults({
         </div>
       ) : null}
 
-      {showSkeleton && <ResultItemSkeletons />}
+      {loading && !hasItems && <ResultItemSkeletons />}
 
       <AnimatePresence initial={false}>
-        {!loading &&
-          Array.isArray(itemsFromList) &&
+        {Array.isArray(itemsFromList) &&
           itemsFromList.map((item: Item) => (
             <AnimatedListItem key={item.id}>
               <ResultItem

--- a/app/hooks/use-items-from-list.tsx
+++ b/app/hooks/use-items-from-list.tsx
@@ -14,13 +14,10 @@ export function preloadListItems(listId: string) {
   preload(getListItemsKey(listId), fetcher);
 }
 
-export function useItemsFromList(listId: string, fallbackData?: Item[]) {
+export function useItemsFromList(listId: string) {
   const { data, isLoading, mutate, error } = useSWR<Item[]>(
     listId ? getListItemsKey(listId) : null,
     fetcher,
-    {
-      ...(fallbackData ? { fallbackData } : {}),
-    },
   );
 
   return {

--- a/app/lists/[listId]/page.tsx
+++ b/app/lists/[listId]/page.tsx
@@ -9,7 +9,6 @@ import { Header } from "@/app/components/header";
 import { ListResults } from "@/app/components/list-results";
 import { getAllLists } from "@/app/data";
 import { getListById } from "@/lib/get-list-by-id";
-import { getListItems } from "@/lib/get-list-items";
 
 type Params = {
   params: { listId: string };
@@ -28,8 +27,6 @@ export async function generateMetadata({ params }: Params) {
 }
 
 export default async function Page({ params }: Params) {
-  const listItemsData = await getListItems(params.listId);
-
   return (
     <main>
       <div className="mx-auto min-h-screen w-full max-w-2xl px-4 pt-4 md:border-l md:border-r md:border-dashed xl:max-w-4xl 2xl:max-w-6xl">
@@ -43,7 +40,6 @@ export default async function Page({ params }: Params) {
           <ListResults
             listId={params.listId}
             listsServerData={listsData}
-            listItemsServerData={listItemsData}
           />
         </div>
       </div>


### PR DESCRIPTION
Fixes #32

## Summary

Automated changes for: **Remove lag experience when opening a never-been-loaded before list**

## Issue Description

There is a obvious, subtle delay when opening a list that has never been loaded/cached. Can we improve the experience by removing the subtle lag? Leverage the optimistic UI if pre-loading the items are causing the UX issue.

## Changes

```
1bee1a1 fix: remove lag when opening a never-loaded list
a526dd7 fix: Improve the experience of viewing a list (#30) (#31)
4f1818f fix: update GitHub setup instructions URL to correct repo (#28)
```

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) Generated with [Claude Code](https://claude.com/claude-code)