### PR TITLE
fix: Seeing "You have no items in your coolection" in the homepage (#40)

### DIFF
--- a/app/components/edit-item-dialog.tsx
+++ b/app/components/edit-item-dialog.tsx
@@ -21,7 +21,7 @@ import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Textarea } from "./ui/textarea";
 
-export function EditItemDialog(itemsServerData: any) {
+export function EditItemDialog({ itemsServerData }: { itemsServerData: any }) {
   const { openEditItemDialog, setOpenEditItemDialog, currentItem } =
     useGlobals();
   const { mutate } = useSWRConfig();

--- a/app/components/main-results.tsx
+++ b/app/components/main-results.tsx
@@ -24,10 +24,13 @@ import { ResultItem } from "./result-item";
 import { ResultItemSkeletons } from "./result-item-skeletons";
 import { Button } from "./ui/button";
 
-export default function MainResults(
-  listsServerData: any,
-  itemsServerData: any,
-) {
+export default function MainResults({
+  listsServerData,
+  itemsServerData,
+}: {
+  listsServerData: any;
+  itemsServerData: any;
+}) {
   const isInList = useIsInList();
   const { mutate } = useSWRConfig();
   const searchParams = useSearchParams();

--- a/app/components/new-item-dialog.tsx
+++ b/app/components/new-item-dialog.tsx
@@ -20,7 +20,7 @@ import {
 } from "./ui/dialog";
 import { Input } from "./ui/input";
 
-export function NewItemDialog(itemsServerData: any) {
+export function NewItemDialog({ itemsServerData }: { itemsServerData: any }) {
   const [inputText, setInputText] = useState("");
   const { openNewItemDialog, setOpenNewItemDialog } = useGlobals();
   const { data: items, mutate: mutateItems } =


### PR DESCRIPTION
Fixes #40

## Summary

Automated changes for: **Seeing "You have no items in your coolection" in the homepage**

## Issue Description

This happened to a user with items saved. They can see the homepage items after switching from another list.

## Changes

```
d428161 fix: destructure props in components so fallbackData reaches SWR
b4cb615 fix: Performance pass on the user interaction and page transition (#34) (#35)
09eecb5 fix: remove lag when opening a never-loaded list (#33)
a526dd7 fix: Improve the experience of viewing a list (#30) (#31)
4f1818f fix: update GitHub setup instructions URL to correct repo (#28)
```

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) Generated with [Claude Code](https://claude.com/claude-code)