### PR TITLE
feat: add light/dark/teal theme support

### DIFF
--- a/app/components/__tests__/sidebar.test.tsx
+++ b/app/components/__tests__/sidebar.test.tsx
@@ -154,23 +154,23 @@ describe("Sidebar", () => {
       mockPathname = "/home";
       render(<Sidebar />);
       const link = screen.getByText("All Bookmarks").closest("a");
-      expect(link?.className).toContain("bg-gray-100");
+      expect(link?.className).toContain("bg-surface-active");
     });
 
     it("highlights the active list", () => {
       mockPathname = "/lists/list-1";
       render(<Sidebar />);
       const designLink = screen.getByText("Design").closest("a");
-      expect(designLink?.className).toContain("bg-gray-100");
+      expect(designLink?.className).toContain("bg-surface-active");
       const workLink = screen.getByText("Work").closest("a");
-      expect(workLink?.className).not.toContain("bg-gray-100");
+      expect(workLink?.className).not.toContain("bg-surface-active");
     });
 
     it("does not highlight All Bookmarks on a list page", () => {
       mockPathname = "/lists/list-1";
       render(<Sidebar />);
       const link = screen.getByText("All Bookmarks").closest("a");
-      expect(link?.className).not.toContain("bg-gray-100");
+      expect(link?.className).not.toContain("bg-surface-active");
     });
   });
 

--- a/app/components/edit-item-dialog.tsx
+++ b/app/components/edit-item-dialog.tsx
@@ -110,7 +110,7 @@ export function EditItemDialog({
 
   return (
     <Dialog open={openEditItemDialog} onOpenChange={setOpenEditItemDialog}>
-      <DialogContent className="bg-white sm:max-w-[425px]">
+      <DialogContent className="bg-bg sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle>Edit item</DialogTitle>
           <DialogDescription>
@@ -142,7 +142,7 @@ export function EditItemDialog({
           </div>
           <DialogFooter>
             <Button
-              className="border-input bg-background hover:bg-accent hover:text-accent-foreground ml-auto w-fit items-center justify-center whitespace-nowrap rounded-md border bg-white/80 px-3 text-sm font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"
+              className="border-input bg-background hover:bg-accent hover:text-accent-foreground ml-auto w-fit items-center justify-center whitespace-nowrap rounded-md border bg-surface px-3 text-sm font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"
               type="submit"
               disabled={!haveChanges}
             >

--- a/app/components/editable-text.tsx
+++ b/app/components/editable-text.tsx
@@ -57,7 +57,7 @@ export function EditableText({
           setValue(event.target.value);
         }}
         className={cn(
-          "flex h-6 select-none items-center justify-center rounded-full border bg-gray-50 px-3 text-center text-xs font-medium",
+          "flex h-6 select-none items-center justify-center rounded-full border bg-surface px-3 text-center text-xs font-medium",
           inputClassName,
         )}
         onKeyDown={(event: React.KeyboardEvent) => {
@@ -92,7 +92,7 @@ export function EditableText({
         inputRef.current?.select();
       }}
       className={cn(
-        "flex h-6 max-w-[240px] cursor-text select-none items-center justify-center truncate rounded-full border bg-gray-50 px-3 text-center text-xs font-medium hover:bg-gray-200",
+        "flex h-6 max-w-[240px] cursor-text select-none items-center justify-center truncate rounded-full border bg-surface px-3 text-center text-xs font-medium hover:bg-surface-hover",
         buttonClassName,
       )}
     >

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -5,10 +5,10 @@ import { cn } from "@/lib/utils";
 
 export function Footer({ type = "root" }: { type?: "home" | "root" }) {
   return (
-    <div className="h-[49px] w-full border-t bg-gray-100/60 p-4 text-xs">
+    <div className="h-[49px] w-full border-t bg-surface p-4 text-xs">
       <div
         className={cn(
-          "mx-auto flex w-full max-w-2xl flex-wrap items-center justify-between gap-2 text-gray-500",
+          "mx-auto flex w-full max-w-2xl flex-wrap items-center justify-between gap-2 text-text-tertiary",
           type === "home" ? "xl:max-w-4xl 2xl:max-w-6xl" : "",
         )}
       >

--- a/app/components/go-back-navigation.tsx
+++ b/app/components/go-back-navigation.tsx
@@ -17,7 +17,7 @@ type ButtonCopyState = "default" | "confirmation" | "loading";
 const buttonCopy = {
   default: "Remove",
   confirmation: "Are you sure?",
-  loading: <Spinner size={16} color="rgba(0, 0, 0, 0.85)" />,
+  loading: <Spinner size={16} color="var(--color-spinner)" />,
 };
 
 export function GoBackNavigation({
@@ -104,13 +104,13 @@ export function GoBackNavigation({
         {/* p-1 is to make focus ring visible */}
         <div className="flex flex-row items-center gap-x-1 p-1">
           <Link href="/home" tabIndex={-1}>
-            <Button className="flex h-6 select-none items-center justify-center rounded-full bg-gray-900 px-3 text-center text-xs font-medium text-white shadow-sm hover:bg-gray-700">
+            <Button className="flex h-6 select-none items-center justify-center rounded-full bg-inverted px-3 text-center text-xs font-medium text-text-inverted shadow-sm hover:opacity-90">
               <ArrowLeftIcon className="mr-1.5 h-3.5 w-3.5" />
               Go back
             </Button>
           </Link>
 
-          <ChevronRightIcon className="h-3.5 w-3.5 text-gray-400" />
+          <ChevronRightIcon className="h-3.5 w-3.5 text-text-quaternary" />
 
           {listId && (
             <EditableText
@@ -129,7 +129,7 @@ export function GoBackNavigation({
         </div>
         <div className="hidden flex-row items-center gap-x-1 md:flex">
           <Button
-            className="relative flex h-6 select-none items-center justify-center overflow-hidden rounded-full border bg-gray-50 px-3 text-center text-xs font-medium hover:bg-gray-200"
+            className="relative flex h-6 select-none items-center justify-center overflow-hidden rounded-full border bg-surface px-3 text-center text-xs font-medium hover:bg-surface-hover"
             disabled={buttonState === "loading"}
             onClick={() => {
               setButtonState("loading");

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -36,7 +36,7 @@ export function Header({
       <div className="flex flex-row items-center justify-between gap-2">
         <div className="flex flex-row items-center space-x-1">
           <Button
-            className="border-input bg-background hover:bg-accent hover:text-accent-foreground h-[30px] items-center justify-center whitespace-nowrap rounded-lg border bg-white px-2 text-xs font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1"
+            className="border-input bg-background hover:bg-accent hover:text-accent-foreground h-[30px] items-center justify-center whitespace-nowrap rounded-lg border bg-bg px-2 text-xs font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1"
             onClick={() => setSidebarOpen((prev) => !prev)}
             aria-label={sidebarOpen ? "Close sidebar" : "Open sidebar"}
           >
@@ -52,12 +52,12 @@ export function Header({
             </Link>
           </div>
           {heading && (
-            <span className="ml-1 max-w-[120px] truncate text-xs font-medium text-gray-800">
+            <span className="ml-1 max-w-[120px] truncate text-xs font-medium text-text-primary">
               {heading}
             </span>
           )}
           {listId && (
-            <span className="ml-1 max-w-[240px] truncate text-xs font-medium text-gray-800">
+            <span className="ml-1 max-w-[240px] truncate text-xs font-medium text-text-primary">
               {getListName(listId)}
             </span>
           )}
@@ -69,13 +69,13 @@ export function Header({
             <NewItemDialog itemsServerData={itemsServerData} />
 
             <Link href="/settings">
-              <Button className="border-input bg-background hover:bg-accent hover:text-accent-foreground h-[30px] items-center justify-center whitespace-nowrap rounded-lg border bg-white px-3 text-xs font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50">
+              <Button className="border-input bg-background hover:bg-accent hover:text-accent-foreground h-[30px] items-center justify-center whitespace-nowrap rounded-lg border bg-bg px-3 text-xs font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50">
                 <SettingsIcon className="h-4 w-4" />
               </Button>
             </Link>
 
             <Button
-              className="border-input bg-background hover:bg-accent hover:text-accent-foreground h-[30px] items-center justify-center whitespace-nowrap rounded-lg border bg-white px-3 text-xs font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"
+              className="border-input bg-background hover:bg-accent hover:text-accent-foreground h-[30px] items-center justify-center whitespace-nowrap rounded-lg border bg-bg px-3 text-xs font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"
               onClick={() => signOut()}
             >
               <LogOutIcon className="h-4 w-4" />

--- a/app/components/highlight-chars.tsx
+++ b/app/components/highlight-chars.tsx
@@ -20,7 +20,7 @@ export function HighlightChars({
         part.toLowerCase() === searchTerm.toLowerCase() ? (
           <span
             key={idx}
-            className="rounded-sm bg-slate-200 box-decoration-clone"
+            className="rounded-sm bg-highlight box-decoration-clone"
           >
             {part}
           </span>

--- a/app/components/list-results.tsx
+++ b/app/components/list-results.tsx
@@ -48,7 +48,7 @@ export function ListResults({
     <div className="mb-8">
         {showEmptyListItemsCopy ? (
           <div className="mt-4 flex min-h-48 w-full items-center justify-center">
-            <p className="max-w-[80%] truncate text-center text-sm font-medium text-gray-700">
+            <p className="max-w-[80%] truncate text-center text-sm font-medium text-text-secondary">
               There is nothing in this list yet.
             </p>
           </div>

--- a/app/components/main-results.tsx
+++ b/app/components/main-results.tsx
@@ -122,7 +122,7 @@ export default function MainResults({
   return (
     <div>
         {showEmptyItemsCopy ? (
-          <p className="mt-4 text-center text-sm font-medium text-gray-700">
+          <p className="mt-4 text-center text-sm font-medium text-text-secondary">
             You have no items in your coolection. Start by{" "}
             <span
               className="cursor-pointer text-sky-400 hover:underline"
@@ -136,7 +136,7 @@ export default function MainResults({
 
         {showNoResults ? (
           <div className="mt-4 flex w-full items-center justify-center">
-            <p className="max-w-[80%] truncate text-center text-sm font-medium text-gray-700">
+            <p className="max-w-[80%] truncate text-center text-sm font-medium text-text-secondary">
               No results for <q>{querySearchParam}</q>
             </p>
           </div>
@@ -175,7 +175,7 @@ export default function MainResults({
         {showLoadMore && (
           <div>
             <Button
-              className="h-[30px] w-full items-center justify-center whitespace-nowrap rounded-lg border bg-white px-3 text-xs font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"
+              className="h-[30px] w-full items-center justify-center whitespace-nowrap rounded-lg border bg-bg px-3 text-xs font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"
               disabled={isLoadingOrValidating}
               onClick={() => (error ? mutateItems() : loadMore())}
             >
@@ -214,7 +214,7 @@ export default function MainResults({
             >
               <CircleArrowUpIcon
                 strokeWidth={1.5}
-                className="h-6 w-6 cursor-pointer rounded-full text-gray-500 drop-shadow backdrop-blur-sm"
+                className="h-6 w-6 cursor-pointer rounded-full text-text-tertiary drop-shadow backdrop-blur-sm"
                 onClick={() =>
                   window.scrollTo({ top: 0, behavior: "smooth" })
                 }

--- a/app/components/new-item-dialog.tsx
+++ b/app/components/new-item-dialog.tsx
@@ -109,12 +109,12 @@ export function NewItemDialog({
   return (
     <Dialog open={openNewItemDialog} onOpenChange={setOpenNewItemDialog}>
       <DialogTrigger asChild>
-        <Button className="border-input bg-background hover:bg-accent hover:text-accent-foreground ml-auto h-[30px] items-center justify-center whitespace-nowrap rounded-lg border bg-white px-3 text-xs font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50">
+        <Button className="border-input bg-background hover:bg-accent hover:text-accent-foreground ml-auto h-[30px] items-center justify-center whitespace-nowrap rounded-lg border bg-bg px-3 text-xs font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50">
           <PlusIcon className="mr-1 h-4 w-4" />
           New Item
         </Button>
       </DialogTrigger>
-      <DialogContent className="bg-white sm:max-w-[425px]">
+      <DialogContent className="bg-bg sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle>New item</DialogTitle>
           <DialogDescription>
@@ -133,7 +133,7 @@ export function NewItemDialog({
           </div>
           <DialogFooter>
             <Button
-              className="border-input bg-background hover:bg-accent hover:text-accent-foreground ml-auto w-fit items-center justify-center whitespace-nowrap rounded-md border bg-white/80 px-3 text-sm font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"
+              className="border-input bg-background hover:bg-accent hover:text-accent-foreground ml-auto w-fit items-center justify-center whitespace-nowrap rounded-md border bg-surface px-3 text-sm font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"
               type="submit"
               disabled={!inputText.trim()}
             >

--- a/app/components/new-list-dialog.tsx
+++ b/app/components/new-list-dialog.tsx
@@ -68,7 +68,7 @@ export function NewListDialog() {
 
   return (
     <Dialog open={openNewListDialog} onOpenChange={setOpenNewListDialog}>
-      <DialogContent className="bg-white sm:max-w-[425px]">
+      <DialogContent className="bg-bg sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle>New list</DialogTitle>
           <DialogDescription>
@@ -90,7 +90,7 @@ export function NewListDialog() {
           </div>
           <DialogFooter>
             <Button
-              className=" border-input bg-background hover:bg-accent hover:text-accent-foreground ml-auto w-fit items-center justify-center whitespace-nowrap rounded-md border bg-white/80 px-3 text-sm font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"
+              className=" border-input bg-background hover:bg-accent hover:text-accent-foreground ml-auto w-fit items-center justify-center whitespace-nowrap rounded-md border bg-surface px-3 text-sm font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"
               type="submit"
               disabled={!listName}
             >

--- a/app/components/result-item.tsx
+++ b/app/components/result-item.tsx
@@ -183,7 +183,7 @@ export const ResultItem = React.memo(function ResultItem({
             setCurrentItem(item);
           }}
         >
-          <div className="flex select-none flex-col py-4 visited:bg-gray-50 hover:rounded-lg hover:bg-gray-50 hover:shadow">
+          <div className="flex select-none flex-col py-4 hover:rounded-lg hover:bg-surface hover:shadow">
             <div className="flex flex-col gap-1 px-4">
               <h3 className="line-clamp-1 text-sm font-medium">
                 <HighlightChars
@@ -198,21 +198,21 @@ export const ResultItem = React.memo(function ResultItem({
                 ) : item.type === ItemType._TWEET ? (
                   <Twitter className="h-3 w-3 text-sky-400" />
                 ) : (
-                  <LinkIcon className="h-3 w-3 text-gray-400" />
+                  <LinkIcon className="h-3 w-3 text-icon-default" />
                 )}
-                <p className="text-sm text-gray-400">
+                <p className="text-sm text-text-quaternary">
                   <HighlightChars
                     text={extractDomain(String(item.url))}
                     searchTerm={querySearchParam}
                   />
                 </p>
                 {item.type === ItemType._GITHUB_STAR && item.metadata?.language && (
-                  <span className="text-xs text-gray-400">
+                  <span className="text-xs text-text-quaternary">
                     {item.metadata.language}
                   </span>
                 )}
               </div>
-              <p className="line-clamp-3 text-sm text-gray-600">
+              <p className="line-clamp-3 text-sm text-text-secondary">
                 <HighlightChars
                   text={getDescription() ?? ""}
                   searchTerm={querySearchParam}

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -48,7 +48,7 @@ export function SearchBar() {
         ref={inputRef}
         id="search"
         type="text"
-        className="focus:shadow-outline w-full appearance-none rounded border bg-black/5 px-3 py-2 pl-8 pr-8 text-sm leading-tight text-gray-700 shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1"
+        className="focus:shadow-outline w-full appearance-none rounded border bg-input-bg px-3 py-2 pl-8 pr-8 text-sm leading-tight text-text-secondary shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1"
         placeholder="What are you looking for?"
         defaultValue={querySearchParam}
         onChange={handleSearch}

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -34,12 +34,12 @@ export function Sidebar() {
       )}
 
       <aside
-        className={`fixed left-0 top-0 z-50 flex h-dvh w-64 flex-col border-r border-dashed bg-white transition-transform duration-200 ease-out md:sticky md:z-0 md:transition-[width,min-width] md:duration-200 ${sidebarOpen ? "translate-x-0 md:min-w-[256px]" : "-translate-x-full md:min-w-0 md:w-0 md:translate-x-0 md:overflow-hidden md:border-0"}`}
+        className={`fixed left-0 top-0 z-50 flex h-dvh w-64 flex-col border-r border-dashed bg-bg transition-transform duration-200 ease-out md:sticky md:z-0 md:transition-[width,min-width] md:duration-200 ${sidebarOpen ? "translate-x-0 md:min-w-[256px]" : "-translate-x-full md:min-w-0 md:w-0 md:translate-x-0 md:overflow-hidden md:border-0"}`}
       >
         <div className="flex items-center justify-between border-b border-dashed px-3 py-3">
-          <span className="text-xs font-medium text-gray-500">Lists</span>
+          <span className="text-xs font-medium text-text-tertiary">Lists</span>
           <Button
-            className="flex h-6 w-6 items-center justify-center rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-600 md:hidden"
+            className="flex h-6 w-6 items-center justify-center rounded-md text-text-quaternary hover:bg-surface-hover hover:text-text-secondary md:hidden"
             onClick={() => setSidebarOpen(false)}
             aria-label="Close sidebar"
           >
@@ -56,8 +56,8 @@ export function Sidebar() {
               }}
               className={`flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors ${
                 isHome
-                  ? "bg-gray-100 text-gray-900"
-                  : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                  ? "bg-surface-active text-text-primary"
+                  : "text-text-secondary hover:bg-surface hover:text-text-primary"
               }`}
             >
               <HomeIcon className="h-3.5 w-3.5" />
@@ -78,8 +78,8 @@ export function Sidebar() {
                   title={list.name}
                   className={`flex items-center gap-2 truncate rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors ${
                     isActive
-                      ? "bg-gray-100 text-gray-900"
-                      : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                      ? "bg-surface-active text-text-primary"
+                      : "text-text-secondary hover:bg-surface hover:text-text-primary"
                   }`}
                 >
                   {list.source === "gh" ? (
@@ -96,7 +96,7 @@ export function Sidebar() {
 
         <div className="border-t border-dashed p-2 h-[49px] flex items-center">
           <Button
-            className="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-900"
+            className="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs font-medium text-text-tertiary transition-colors hover:bg-surface hover:text-text-primary"
             onClick={() => setOpenNewListDialog(true)}
           >
             <ListPlusIcon className="h-3.5 w-3.5" />

--- a/app/components/themed-toaster.tsx
+++ b/app/components/themed-toaster.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Toaster } from "sonner";
+
+export function ThemedToaster() {
+  const { resolvedTheme } = useTheme();
+  return <Toaster theme={resolvedTheme === "light" ? "light" : "dark"} />;
+}

--- a/app/components/ui/context-menu.tsx
+++ b/app/components/ui/context-menu.tsx
@@ -29,7 +29,7 @@ const ContextMenuSubTrigger = React.forwardRef<
     className={cn(
       // "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
       "flex w-full cursor-default select-none items-center rounded-md px-2 py-2 text-xs outline-none",
-      "text-gray-500 focus:bg-gray-50 ",
+      "text-text-tertiary focus:bg-surface-hover ",
       inset && "pl-8",
       className,
     )}
@@ -50,7 +50,7 @@ const ContextMenuSubContent = React.forwardRef<
     sideOffset={4}
     collisionPadding={8}
     className={cn(
-      "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border bg-white p-1 shadow-md",
+      "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border bg-bg p-1 shadow-md",
       className,
     )}
     {...props}
@@ -69,7 +69,7 @@ const ContextMenuContent = React.forwardRef<
       className={cn(
         "bg-popover text-popover-foreground animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 radix-side-top:animate-slide-up radix-side-bottom:animate-slide-down z-50 min-w-[8rem] overflow-hidden rounded-md border border p-1 shadow-md",
         "rounded-lg px-1.5 py-1 shadow-md",
-        "bg-white",
+        "bg-bg",
         className,
       )}
       {...props}
@@ -89,7 +89,7 @@ const ContextMenuItem = React.forwardRef<
     className={cn(
       // "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       "flex cursor-default select-none items-center rounded-md px-2 py-2 text-xs outline-none",
-      "text-gray-500 focus:bg-gray-50 ",
+      "text-text-tertiary focus:bg-surface-hover ",
       inset && "pl-8",
       className,
     )}

--- a/app/components/ui/dialog.tsx
+++ b/app/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-white/30 backdrop-blur-sm",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-overlay backdrop-blur-sm",
       className,
     )}
     {...props}
@@ -102,7 +102,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-gray-500", className)}
+    className={cn("text-sm text-text-tertiary", className)}
     {...props}
   />
 ));

--- a/app/components/ui/skeleton.tsx
+++ b/app/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-gray-100", className)}
+      className={cn("animate-pulse rounded-md bg-skeleton", className)}
       {...props}
     />
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,38 +2,155 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
+/* ── Theme tokens ─────────────────────────────────────────────────── */
+
+:root,
+[data-theme="light"] {
+  --color-bg: #ffffff;
+  --color-bg-surface: #f9fafb;
+  --color-bg-surface-hover: #f3f4f6;
+  --color-bg-surface-active: #f3f4f6;
+  --color-bg-input: rgba(0, 0, 0, 0.05);
+  --color-bg-overlay: rgba(255, 255, 255, 0.3);
+  --color-bg-skeleton: #f3f4f6;
+  --color-bg-highlight: #e2e8f0;
+  --color-bg-inverted: rgba(0, 0, 0, 0.8);
+  --color-text-primary: #111827;
+  --color-text-secondary: #374151;
+  --color-text-tertiary: #6b7280;
+  --color-text-quaternary: #9ca3af;
+  --color-text-inverted: #ffffff;
+  --color-text-accent: inherit;
+  --color-border: #e5e7eb;
+  --color-border-strong: #d1d5db;
+  --color-icon-default: #6b7280;
+  --color-spinner: rgba(0, 0, 0, 0.85);
+
+  /* Shadcn compatibility */
+  --background: var(--color-bg);
+  --foreground: var(--color-text-primary);
+  --primary: var(--color-bg-inverted);
+  --primary-foreground: var(--color-text-inverted);
+  --secondary: var(--color-bg-surface);
+  --secondary-foreground: var(--color-text-primary);
+  --muted: var(--color-bg-surface);
+  --muted-foreground: var(--color-text-tertiary);
+  --accent: var(--color-bg-surface-hover);
+  --accent-foreground: var(--color-text-primary);
+  --popover: var(--color-bg);
+  --popover-foreground: var(--color-text-primary);
+  --destructive: #ef4444;
+  --destructive-foreground: #ffffff;
+  --border: var(--color-border);
+  --input: var(--color-border);
+  --ring: var(--color-border-strong);
+  --ring-offset: var(--color-bg);
+
+  color-scheme: light;
 }
 
-/* @media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
-} */
+[data-theme="dark"] {
+  --color-bg: #030712;
+  --color-bg-surface: #111827;
+  --color-bg-surface-hover: #1f2937;
+  --color-bg-surface-active: #1f2937;
+  --color-bg-input: rgba(255, 255, 255, 0.05);
+  --color-bg-overlay: rgba(0, 0, 0, 0.5);
+  --color-bg-skeleton: #1f2937;
+  --color-bg-highlight: #334155;
+  --color-bg-inverted: rgba(255, 255, 255, 0.9);
+  --color-text-primary: #f3f4f6;
+  --color-text-secondary: #d1d5db;
+  --color-text-tertiary: #9ca3af;
+  --color-text-quaternary: #6b7280;
+  --color-text-inverted: #111827;
+  --color-text-accent: inherit;
+  --color-border: #374151;
+  --color-border-strong: #4b5563;
+  --color-icon-default: #9ca3af;
+  --color-spinner: rgba(255, 255, 255, 0.85);
+
+  --background: var(--color-bg);
+  --foreground: var(--color-text-primary);
+  --primary: var(--color-bg-inverted);
+  --primary-foreground: var(--color-text-inverted);
+  --secondary: var(--color-bg-surface);
+  --secondary-foreground: var(--color-text-primary);
+  --muted: var(--color-bg-surface);
+  --muted-foreground: var(--color-text-tertiary);
+  --accent: var(--color-bg-surface-hover);
+  --accent-foreground: var(--color-text-primary);
+  --popover: var(--color-bg);
+  --popover-foreground: var(--color-text-primary);
+  --destructive: #ef4444;
+  --destructive-foreground: #ffffff;
+  --border: var(--color-border);
+  --input: var(--color-border);
+  --ring: var(--color-border-strong);
+  --ring-offset: var(--color-bg);
+
+  color-scheme: dark;
+}
+
+[data-theme="teal"] {
+  --color-bg: #030712;
+  --color-bg-surface: #111827;
+  --color-bg-surface-hover: #1f2937;
+  --color-bg-surface-active: rgba(45, 212, 191, 0.1);
+  --color-bg-input: rgba(255, 255, 255, 0.05);
+  --color-bg-overlay: rgba(0, 0, 0, 0.5);
+  --color-bg-skeleton: #1f2937;
+  --color-bg-highlight: #134e4a;
+  --color-bg-inverted: #2dd4bf;
+  --color-text-primary: #f3f4f6;
+  --color-text-secondary: #d1d5db;
+  --color-text-tertiary: #9ca3af;
+  --color-text-quaternary: #6b7280;
+  --color-text-inverted: #030712;
+  --color-text-accent: #2dd4bf;
+  --color-border: #374151;
+  --color-border-strong: #0d9488;
+  --color-icon-default: #9ca3af;
+  --color-spinner: #2dd4bf;
+
+  --background: var(--color-bg);
+  --foreground: var(--color-text-primary);
+  --primary: var(--color-bg-inverted);
+  --primary-foreground: var(--color-text-inverted);
+  --secondary: var(--color-bg-surface);
+  --secondary-foreground: var(--color-text-primary);
+  --muted: var(--color-bg-surface);
+  --muted-foreground: var(--color-text-tertiary);
+  --accent: var(--color-bg-surface-hover);
+  --accent-foreground: var(--color-text-primary);
+  --popover: var(--color-bg);
+  --popover-foreground: var(--color-text-primary);
+  --destructive: #ef4444;
+  --destructive-foreground: #ffffff;
+  --border: var(--color-border);
+  --input: var(--color-border);
+  --ring: var(--color-border-strong);
+  --ring-offset: var(--color-bg);
+
+  color-scheme: dark;
+}
+
+/* ── Global styles ────────────────────────────────────────────────── */
 
 body {
-  color: rgb(var(--foreground-rgb));
-  background: #ffffff;
+  background: var(--color-bg);
+  color: var(--color-text-primary);
 }
 
 .simple-bg {
-  background: linear-gradient(to bottom, transparent, #fcfcfd) white;
-}
-
-@layer utilities {
-  button {
-    @apply hover:bg-gray-50;
-  }
+  background: linear-gradient(to bottom, transparent, var(--color-bg)) var(--color-bg);
 }
 
 .background-gradient-pattern {
-  background-image: radial-gradient(#a4a4a3, transparent 50%);
+  background-image: radial-gradient(var(--color-text-quaternary), transparent 50%);
 }
+
+/* ── Spinner ──────────────────────────────────────────────────────── */
 
 .bar {
   animation: loading-spin 1.2s linear infinite;

--- a/app/hooks/use-clipboard-url.tsx
+++ b/app/hooks/use-clipboard-url.tsx
@@ -26,7 +26,7 @@ export function useClipboardUrl(
       toast("URL found in clipboard", {
         description: trimmed,
         classNames: {
-          description: "!text-sm !text-gray-400 line-clamp-2 break-all",
+          description: "!text-sm !text-text-quaternary line-clamp-2 break-all",
         },
         action: {
           label: "Save",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,13 +4,13 @@ import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata, Viewport } from "next";
 import { ViewTransitions } from "next-view-transitions";
-import { Toaster } from "sonner";
 
 import { fontSans } from "@/lib/fonts";
 
 import { ClipboardUrlSuggestion } from "./components/clipboard-url-suggestion";
 import { Sidebar } from "./components/sidebar";
 import { TailwindIndicator } from "./components/tailwind-indicator";
+import { ThemedToaster } from "./components/themed-toaster";
 import { Providers } from "./providers";
 
 export const metadata: Metadata = {
@@ -34,7 +34,10 @@ export const metadata: Metadata = {
 
 // See: https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone
 export const viewport: Viewport = {
-  themeColor: "#FFFFFF",
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#030712" },
+  ],
   width: "device-width",
   initialScale: 1,
   maximumScale: 1,
@@ -47,10 +50,10 @@ export default function RootLayout({
 }>) {
   return (
     <ViewTransitions>
-      <html lang="en">
+      <html lang="en" suppressHydrationWarning>
         <body className={fontSans.className}>
           <Providers>
-            <Toaster />
+            <ThemedToaster />
             <ClipboardUrlSuggestion />
             <Analytics />
             <div className="flex">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,7 +65,7 @@ export default async function RootPage() {
         />
 
         <svg
-          className="pointer-events-none absolute inset-0 h-full w-full stroke-gray-200 opacity-50 [mask-image:radial-gradient(100%_100%_at_top_center,white,transparent)]"
+          className="pointer-events-none absolute inset-0 h-full w-full stroke-border opacity-50 [mask-image:radial-gradient(100%_100%_at_top_center,white,transparent)]"
           aria-hidden="true"
         >
           <defs>
@@ -80,7 +80,7 @@ export default async function RootPage() {
               <path d="M100 200V.5M.5 .5H200" fill="none" />
             </pattern>
           </defs>
-          <svg x="50%" y="-1" className="overflow-visible fill-gray-50">
+          <svg x="50%" y="-1" className="overflow-visible fill-surface">
             <path
               d="M-100.5 0h201v201h-201Z M699.5 0h201v201h-201Z M499.5 400h201v201h-201Z M-300.5 600h201v201h-201Z"
               strokeWidth="0"
@@ -95,11 +95,11 @@ export default async function RootPage() {
         </svg>
 
         <div className="relative z-20 mx-auto w-full max-w-2xl px-4 text-center">
-          <h1 className="font-serif text-4xl font-extrabold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">
+          <h1 className="font-serif text-4xl font-extrabold tracking-tight text-text-primary sm:text-5xl lg:text-6xl">
             Your bookmarks, everywhere
           </h1>
 
-          <p className="mx-auto mt-6 max-w-lg text-lg text-gray-600">
+          <p className="mx-auto mt-6 max-w-lg text-lg text-text-secondary">
             <Balancer>
               Save from Chrome, Safari, or the web. Find anything instantly.
             </Balancer>
@@ -108,7 +108,7 @@ export default async function RootPage() {
           <div className="mt-10">
             <Link
               href="/sign-in"
-              className="text-md group inline-flex items-center rounded-full bg-black/80 px-5 py-2.5 font-semibold text-white transition-colors hover:bg-black/90"
+              className="text-md group inline-flex items-center rounded-full bg-inverted px-5 py-2.5 font-semibold text-text-inverted transition-colors hover:opacity-90"
             >
               Get started
               <ArrowRightIcon className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-0.5" />
@@ -123,18 +123,18 @@ export default async function RootPage() {
         className="w-full py-20 md:py-28"
       >
         <div className="mx-auto max-w-2xl px-4">
-          <h2 className="text-center font-serif text-2xl font-bold text-gray-900 sm:text-3xl">
+          <h2 className="text-center font-serif text-2xl font-bold text-text-primary sm:text-3xl">
             Save from anywhere
           </h2>
 
           <div className="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-3">
             {platforms.map((platform) => (
               <div key={platform.label} className="text-center">
-                <platform.icon className="mx-auto h-6 w-6 text-gray-400" />
-                <p className="mt-3 text-sm font-medium text-gray-900">
+                <platform.icon className="mx-auto h-6 w-6 text-icon-default" />
+                <p className="mt-3 text-sm font-medium text-text-primary">
                   {platform.label}
                 </p>
-                <p className="mt-1 text-sm text-gray-500">
+                <p className="mt-1 text-sm text-text-tertiary">
                   {platform.description}
                 </p>
               </div>
@@ -150,13 +150,13 @@ export default async function RootPage() {
             {features.map((feature) => (
               <div
                 key={feature.label}
-                className="rounded-lg bg-gray-50 p-6"
+                className="rounded-lg bg-surface p-6"
               >
-                <feature.icon className="h-5 w-5 text-gray-400" />
-                <p className="mt-3 text-sm font-medium text-gray-900">
+                <feature.icon className="h-5 w-5 text-icon-default" />
+                <p className="mt-3 text-sm font-medium text-text-primary">
                   {feature.label}
                 </p>
-                <p className="mt-1 text-sm leading-relaxed text-gray-500">
+                <p className="mt-1 text-sm leading-relaxed text-text-tertiary">
                   {feature.description}
                 </p>
               </div>
@@ -168,15 +168,15 @@ export default async function RootPage() {
       {/* Product Preview */}
       <section aria-label="Preview" className="w-full py-20 md:py-28">
         <div className="mx-auto max-w-4xl px-4">
-          <div className="overflow-hidden rounded-xl border border-gray-200 shadow-sm">
+          <div className="overflow-hidden rounded-xl border shadow-sm">
             {/* Browser title bar */}
-            <div className="flex items-center gap-1.5 bg-gray-100 px-4 py-3">
-              <span className="h-2.5 w-2.5 rounded-full bg-gray-300" />
-              <span className="h-2.5 w-2.5 rounded-full bg-gray-300" />
-              <span className="h-2.5 w-2.5 rounded-full bg-gray-300" />
+            <div className="flex items-center gap-1.5 bg-surface-hover px-4 py-3">
+              <span className="h-2.5 w-2.5 rounded-full bg-border-strong" />
+              <span className="h-2.5 w-2.5 rounded-full bg-border-strong" />
+              <span className="h-2.5 w-2.5 rounded-full bg-border-strong" />
             </div>
             {/* Demo video */}
-            <div className="relative aspect-[16/10] w-full bg-white">
+            <div className="relative aspect-[16/10] w-full bg-bg">
               <video
                 src="/demo-dashboard.mp4"
                 autoPlay
@@ -195,14 +195,14 @@ export default async function RootPage() {
       {/* Self-hosting */}
       <section
         aria-label="Self-hosting"
-        className="w-full bg-gray-50 py-20 md:py-28"
+        className="w-full bg-surface py-20 md:py-28"
       >
         <div className="mx-auto max-w-2xl px-4 text-center">
-          <h2 className="font-serif text-2xl font-bold text-gray-900 sm:text-3xl">
+          <h2 className="font-serif text-2xl font-bold text-text-primary sm:text-3xl">
             Open source &amp; self-hosted
           </h2>
 
-          <p className="mx-auto mt-4 max-w-md text-gray-600">
+          <p className="mx-auto mt-4 max-w-md text-text-secondary">
             Run Coolection on your own infrastructure. Fully open source.
           </p>
 
@@ -211,7 +211,7 @@ export default async function RootPage() {
               href="https://github.com/lovincyrus/coolection"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center rounded-full border border-gray-300 bg-white px-5 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+              className="inline-flex items-center rounded-full border bg-bg px-5 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:bg-surface"
             >
               View on GitHub
               <ArrowRightIcon className="ml-2 h-3.5 w-3.5" />

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -8,13 +8,13 @@ export default function PrivacyPage() {
   return (
     <main className="flex min-h-screen flex-col">
       <div className="mx-auto w-full max-w-2xl flex-1 px-4 py-20">
-        <h1 className="font-serif text-3xl font-bold text-gray-900">
+        <h1 className="font-serif text-3xl font-bold text-text-primary">
           Privacy Policy
         </h1>
 
-        <div className="mt-8 space-y-6 text-sm leading-relaxed text-gray-600">
+        <div className="mt-8 space-y-6 text-sm leading-relaxed text-text-secondary">
           <section>
-            <h2 className="text-sm font-medium text-gray-900">
+            <h2 className="text-sm font-medium text-text-primary">
               How Coolection uses your data
             </h2>
             <p className="mt-2">
@@ -25,7 +25,7 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-sm font-medium text-gray-900">
+            <h2 className="text-sm font-medium text-text-primary">
               Browser extensions
             </h2>
             <p className="mt-2">
@@ -38,7 +38,7 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-sm font-medium text-gray-900">
+            <h2 className="text-sm font-medium text-text-primary">
               What we do not collect
             </h2>
             <p className="mt-2">
@@ -49,12 +49,12 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-sm font-medium text-gray-900">Contact</h2>
+            <h2 className="text-sm font-medium text-text-primary">Contact</h2>
             <p className="mt-2">
               Questions about this policy? Reach out at{" "}
               <a
                 href="mailto:hello@coolection.co"
-                className="font-medium text-gray-900 hover:underline"
+                className="font-medium text-text-primary hover:underline"
               >
                 hello@coolection.co
               </a>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { ClerkProvider } from "@clerk/nextjs";
+import { dark } from "@clerk/themes";
 import {
   simpleStorageHandler,
   useCacheProvider,
 } from "@piotr-cz/swr-idb-cache";
+import { ThemeProvider, useTheme } from "next-themes";
 import { SWRConfig } from "swr";
 
 import { DEFAULT_PAGE_SIZE } from "@/lib/constants";
@@ -22,6 +24,17 @@ const storageHandler = {
       : undefined,
 };
 
+function ClerkWithTheme({ children }: { children: React.ReactNode }) {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark" || resolvedTheme === "teal";
+
+  return (
+    <ClerkProvider appearance={isDark ? { baseTheme: dark } : undefined}>
+      {children}
+    </ClerkProvider>
+  );
+}
+
 export function Providers({ children }: { children: React.ReactNode }) {
   const cacheProvider = useCacheProvider({
     dbName: "coolection_db",
@@ -34,21 +47,27 @@ export function Providers({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <ClerkProvider>
-      <SWRConfig
-        value={{
-          provider: cacheProvider,
-          fallback: {
-            "/api/lists": getAllLists(),
-            [`/api/items?page=1&limit=${DEFAULT_PAGE_SIZE}`]: getItems(
-              1,
-              DEFAULT_PAGE_SIZE,
-            ),
-          },
-        }}
-      >
-        <GlobalsProvider>{children}</GlobalsProvider>
-      </SWRConfig>
-    </ClerkProvider>
+    <ThemeProvider
+      attribute="data-theme"
+      defaultTheme="system"
+      disableTransitionOnChange
+    >
+      <ClerkWithTheme>
+        <SWRConfig
+          value={{
+            provider: cacheProvider,
+            fallback: {
+              "/api/lists": getAllLists(),
+              [`/api/items?page=1&limit=${DEFAULT_PAGE_SIZE}`]: getItems(
+                1,
+                DEFAULT_PAGE_SIZE,
+              ),
+            },
+          }}
+        >
+          <GlobalsProvider>{children}</GlobalsProvider>
+        </SWRConfig>
+      </ClerkWithTheme>
+    </ThemeProvider>
   );
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,12 +1,20 @@
 "use client";
 
-import { ClipboardCopyIcon, ExternalLinkIcon, KeyIcon, StarIcon, TrashIcon, Twitter } from "lucide-react";
+import { ClipboardCopyIcon, ExternalLinkIcon, KeyIcon, MonitorIcon, MoonIcon, PaletteIcon, StarIcon, SunIcon, TrashIcon, Twitter } from "lucide-react";
+import { useTheme } from "next-themes";
 import { Link } from "next-view-transitions";
 import React, { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/app/components/ui/button";
 import { Input } from "@/app/components/ui/input";
+
+const themes = [
+  { value: "system", label: "System", description: "Follow your OS preference", icon: MonitorIcon },
+  { value: "light", label: "Light", description: "Light background", icon: SunIcon },
+  { value: "dark", label: "Dark", description: "Dark background", icon: MoonIcon },
+  { value: "teal", label: "Teal", description: "Dark with teal accents", icon: PaletteIcon },
+] as const;
 
 interface TokenInfo {
   id: string;
@@ -38,6 +46,7 @@ function formatLastUsed(iso: string | null) {
 }
 
 export default function SettingsPage() {
+  const { theme, setTheme } = useTheme();
   const [tokens, setTokens] = useState<TokenInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [newToken, setNewToken] = useState<string | null>(null);
@@ -180,7 +189,7 @@ export default function SettingsPage() {
                   />
                 </Link>
               </div>
-              <span className="ml-1 text-xs font-medium text-gray-800">
+              <span className="ml-1 text-xs font-medium text-text-primary">
                 Settings
               </span>
             </div>
@@ -188,10 +197,41 @@ export default function SettingsPage() {
         </div>
 
         <div className="mt-14 flex flex-col gap-6">
+          {/* Appearance */}
           <div className="flex items-start justify-between">
             <div>
-              <h2 className="text-sm font-medium text-gray-900">API Tokens</h2>
-              <p className="mt-1 text-xs text-gray-500">
+              <h2 className="text-sm font-medium text-text-primary">Appearance</h2>
+              <p className="mt-1 text-xs text-text-tertiary">
+                Choose your preferred theme
+              </p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {themes.map((t) => (
+              <button
+                key={t.value}
+                onClick={() => setTheme(t.value)}
+                className={`flex flex-col items-center gap-2 rounded-md border border-dashed p-4 text-center transition-colors ${
+                  theme === t.value
+                    ? "border-border-strong bg-surface-active text-text-primary"
+                    : "text-text-tertiary hover:bg-surface hover:text-text-primary"
+                }`}
+              >
+                <t.icon className="h-5 w-5" />
+                <span className="text-xs font-medium">{t.label}</span>
+                <span className="text-[10px] leading-tight text-text-quaternary">{t.description}</span>
+              </button>
+            ))}
+          </div>
+
+          <hr className="my-4 border-dashed" />
+
+          {/* API Tokens */}
+          <div className="flex items-start justify-between">
+            <div>
+              <h2 className="text-sm font-medium text-text-primary">API Tokens</h2>
+              <p className="mt-1 text-xs text-text-tertiary">
                 Generate tokens to use with the Coolection browser extensions.
               </p>
             </div>
@@ -209,7 +249,7 @@ export default function SettingsPage() {
 
           {showForm && (
             <div className="flex flex-col gap-3 rounded-md border border-dashed p-4">
-              <label className="text-xs font-medium text-gray-700">
+              <label className="text-xs font-medium text-text-secondary">
                 Token name
               </label>
               <Input
@@ -252,7 +292,7 @@ export default function SettingsPage() {
           {newToken && (
             <div className="flex flex-col gap-2">
               <div className="flex items-center gap-2">
-                <code className="flex-1 break-all rounded-md border bg-gray-50 px-3 py-2 text-xs">
+                <code className="flex-1 break-all rounded-md border bg-surface px-3 py-2 text-xs">
                   {newToken}
                 </code>
                 <Button
@@ -272,11 +312,11 @@ export default function SettingsPage() {
           )}
 
           {loading ? (
-            <div className="py-8 text-center text-xs text-gray-400">
+            <div className="py-8 text-center text-xs text-text-quaternary">
               Loading...
             </div>
           ) : tokens.length === 0 ? (
-            <div className="rounded-md border border-dashed py-8 text-center text-xs text-gray-400">
+            <div className="rounded-md border border-dashed py-8 text-center text-xs text-text-quaternary">
               No tokens yet. Create one to start using extensions.
             </div>
           ) : (
@@ -284,18 +324,18 @@ export default function SettingsPage() {
               {tokens.map((t) => (
                 <div
                   key={t.id}
-                  className="flex items-center justify-between rounded-md border bg-gray-50 px-4 py-3"
+                  className="flex items-center justify-between rounded-md border bg-surface px-4 py-3"
                 >
                   <div className="flex flex-col gap-0.5">
                     <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium text-gray-900">
+                      <span className="text-sm font-medium text-text-primary">
                         {t.name || "Unnamed token"}
                       </span>
-                      <span className="font-mono text-xs text-gray-400">
+                      <span className="font-mono text-xs text-text-quaternary">
                         ...{t.tokenPrefix}
                       </span>
                     </div>
-                    <span className="text-xs text-gray-500">
+                    <span className="text-xs text-text-tertiary">
                       Created {formatDate(t.createdAt)}
                       {" · "}
                       {formatLastUsed(t.lastUsedAt)}
@@ -305,7 +345,7 @@ export default function SettingsPage() {
                     variant="outline"
                     size="sm"
                     onClick={() => revokeToken(t.id, t.name)}
-                    className="shrink-0 text-xs text-gray-500 hover:text-red-600"
+                    className="shrink-0 text-xs text-text-tertiary hover:text-red-600"
                   >
                     <TrashIcon className="mr-1 h-3 w-3" />
                     Revoke
@@ -319,17 +359,17 @@ export default function SettingsPage() {
 
           <div className="flex items-start justify-between">
             <div>
-              <h2 className="text-sm font-medium text-gray-900">
+              <h2 className="text-sm font-medium text-text-primary">
                 GitHub Stars
               </h2>
-              <p className="mt-1 text-xs text-gray-500">
+              <p className="mt-1 text-xs text-text-tertiary">
                 Sync your starred repositories into your collection.
               </p>
             </div>
           </div>
 
           <div className="flex flex-col gap-3 rounded-md border border-dashed p-4">
-            <label className="text-xs font-medium text-gray-700">
+            <label className="text-xs font-medium text-text-secondary">
               GitHub username
             </label>
             <div className="flex items-center gap-2">
@@ -357,7 +397,7 @@ export default function SettingsPage() {
               </Button>
             </div>
             {syncStatus?.configured && (
-              <p className="text-xs text-gray-500">
+              <p className="text-xs text-text-tertiary">
                 Last synced {syncStatus.lastSyncedAt
                   ? formatLastUsed(syncStatus.lastSyncedAt)
                   : "never"}
@@ -366,7 +406,7 @@ export default function SettingsPage() {
                 )}
               </p>
             )}
-            <p className="text-xs text-gray-400">
+            <p className="text-xs text-text-quaternary">
               Only public stars are synced. Subsequent syncs skip unchanged
               stars.
             </p>
@@ -376,22 +416,22 @@ export default function SettingsPage() {
 
           <div className="flex items-start justify-between">
             <div>
-              <h2 className="text-sm font-medium text-gray-900">
+              <h2 className="text-sm font-medium text-text-primary">
                 <Twitter className="mr-1 inline h-3.5 w-3.5 text-sky-400" />
                 X Bookmarks
               </h2>
-              <p className="mt-1 text-xs text-gray-500">
+              <p className="mt-1 text-xs text-text-tertiary">
                 Sync your X (Twitter) bookmarks using the browser extension.
               </p>
             </div>
           </div>
 
           <div className="flex flex-col gap-3 rounded-md border border-dashed p-4">
-            <p className="text-xs text-gray-600">
+            <p className="text-xs text-text-secondary">
               X bookmarks are synced automatically by the Coolection Chrome
               extension. To get started:
             </p>
-            <ol className="list-inside list-decimal text-xs text-gray-600 space-y-1">
+            <ol className="list-inside list-decimal text-xs text-text-secondary space-y-1">
               <li>Install the Chrome extension from the repo</li>
               <li>Open extension options and paste your API token</li>
               <li>Enable bookmark sync and set your preferred interval</li>
@@ -401,7 +441,7 @@ export default function SettingsPage() {
               href="https://github.com/lovincyrus/coolection"
               target="_blank"
               rel="noreferrer noopener"
-              className="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-900"
+              className="inline-flex items-center gap-1 text-xs text-text-tertiary hover:text-text-primary"
             >
               <ExternalLinkIcon className="h-3 w-3" />
               View setup instructions on GitHub

--- a/docs/brainstorms/2026-02-16-theme-support-brainstorm.md
+++ b/docs/brainstorms/2026-02-16-theme-support-brainstorm.md
@@ -1,0 +1,64 @@
+# Theme Support: Light, Dark, Teal
+
+**Date:** 2026-02-16
+**Status:** Ready for planning
+
+## What We're Building
+
+Three-theme support for Coolection: **light** (current), **dark**, and **teal** (dark background with teal accents). Defaults to OS system preference (light/dark), with a manual override on the settings page. Teal is a third explicit choice.
+
+## Why This Approach
+
+**CSS Variables + `next-themes`**
+
+- Define all color tokens as CSS variables in `globals.css`, scoped per theme via `[data-theme]` attributes
+- Use `next-themes` for system preference detection, localStorage persistence, and SSR flash prevention
+- Tailwind maps to CSS variables (e.g., `bg-surface` resolves to `var(--color-surface)`)
+
+**Rationale:** Single source of truth per theme, clean separation, scales to N themes. `next-themes` is ~2KB and handles the hard hydration/flash problems that are painful to solve by hand.
+
+## Key Decisions
+
+- **3 themes:** Light (default/current), Dark, Teal (dark + teal accents)
+- **System preference + manual override:** OS preference maps to light/dark; teal is opt-in only
+- **Theme switcher location:** Settings page (alongside API token management)
+- **Token-based approach:** Replace hardcoded gray classes with semantic CSS variables
+- **Motivation:** Personal preference, not user-facing feature request
+
+## Theme Definitions (Draft)
+
+### Light (current look)
+- Background: white
+- Surface: gray-50
+- Text: gray-900 / gray-500
+- Borders: gray-200
+- Accents: current sky/amber usage
+
+### Dark
+- Background: gray-950
+- Surface: gray-900
+- Text: gray-100 / gray-400
+- Borders: gray-800
+- Accents: same sky/amber, slightly brighter
+
+### Teal
+- Background: gray-950
+- Surface: gray-900
+- Text: gray-100 / gray-400
+- Borders: teal-800/900
+- Accents: teal-400/500 for links, active states, highlights
+
+## Open Questions
+
+- Should the iOS Safari extension also support themes, or web-only for now?
+- Should bookmark card thumbnails/favicons get a subtle background treatment in dark modes?
+- Exact teal palette values (teal-400 vs teal-500 for primary accent)
+
+## Scope
+
+- Install `next-themes`, add ThemeProvider to layout
+- Define CSS variable tokens for all 3 themes in `globals.css`
+- Update Tailwind config to use CSS variable-based colors
+- Migrate components from hardcoded gray classes to semantic tokens
+- Add theme picker to settings page
+- Handle viewport `themeColor` meta tag per theme

--- a/docs/plans/2026-02-16-feat-theme-support-light-dark-teal-plan.md
+++ b/docs/plans/2026-02-16-feat-theme-support-light-dark-teal-plan.md
@@ -1,0 +1,341 @@
+---
+title: "feat: Add light/dark/teal theme support"
+type: feat
+date: 2026-02-16
+---
+
+# feat: Add light/dark/teal theme support
+
+## Overview
+
+Add three-theme support to Coolection: **Light** (current), **Dark** (gray-950 bg), and **Teal** (dark bg with teal accents). Uses CSS custom properties as semantic color tokens, switched via `next-themes` for system preference detection, localStorage persistence, and SSR flash prevention. Theme picker lives on the settings page.
+
+## Problem Statement / Motivation
+
+The app is light-only with hardcoded white/gray colors across ~23 files (122 color class occurrences). Personal preference for dark and teal modes. The existing shadcn UI components already reference undefined CSS variable tokens (`bg-background`, `text-foreground`, etc.) — this work also fixes that gap.
+
+## Proposed Solution
+
+**CSS variables + `next-themes` + Tailwind semantic colors.**
+
+1. Define semantic color tokens as CSS variables in `globals.css`, scoped per theme via `[data-theme]` selectors
+2. Map those variables to Tailwind color names in `tailwind.config.ts`
+3. Replace all hardcoded gray/white classes with semantic Tailwind classes
+4. Use `next-themes` (`attribute="data-theme"`) for theme switching, system detection, and persistence
+5. Add a 4-option theme picker (System, Light, Dark, Teal) to settings page
+
+## Architectural Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Theme switching mechanism | `data-theme` attribute on `<html>` | Cleaner than class-based for 3+ themes; CSS selectors `[data-theme="dark"]` are explicit |
+| Color system | CSS variables only (no `dark:` prefix) | `dark:` variant only handles 2 states; CSS vars scale to N themes from one source of truth |
+| Theme library | `next-themes` | ~2KB, handles SSR flash, system detection, localStorage + cookie persistence |
+| Tailwind `darkMode` | Not used | Redundant when using CSS variables exclusively |
+| Picker options | System / Light / Dark / Teal | "System" lets users revert to automatic OS detection after manual override |
+| Persistence | Client-side only (localStorage + cookie) | Cross-device sync is a future enhancement |
+| Landing page | Themed | Dark-OS users shouldn't see blinding white on first visit |
+| Theme transition | Instant (no animation) | Simpler; `disableTransitionOnChange: true` |
+
+## Semantic Color Token Design
+
+### Token Vocabulary
+
+| Token | Purpose | Light | Dark | Teal |
+|-------|---------|-------|------|------|
+| `--color-bg` | Page background | `#ffffff` | `#030712` (gray-950) | `#030712` |
+| `--color-bg-surface` | Cards, sidebar, dialogs | `#f9fafb` (gray-50) | `#111827` (gray-900) | `#111827` |
+| `--color-bg-surface-hover` | Hover on surfaces | `#f3f4f6` (gray-100) | `#1f2937` (gray-800) | `#1f2937` |
+| `--color-bg-surface-active` | Active/selected states | `#f3f4f6` (gray-100) | `#1f2937` (gray-800) | `rgba(45,212,191,0.1)` (teal-400/10) |
+| `--color-bg-input` | Search bar, form inputs | `rgba(0,0,0,0.05)` | `rgba(255,255,255,0.05)` | `rgba(255,255,255,0.05)` |
+| `--color-bg-overlay` | Dialog backdrop | `rgba(255,255,255,0.3)` | `rgba(0,0,0,0.5)` | `rgba(0,0,0,0.5)` |
+| `--color-bg-skeleton` | Loading placeholders | `#f3f4f6` (gray-100) | `#1f2937` (gray-800) | `#1f2937` |
+| `--color-bg-highlight` | Search term highlights | `#e2e8f0` (slate-200) | `#334155` (slate-700) | `#134e4a` (teal-900) |
+| `--color-bg-inverted` | Inverted buttons (CTA) | `rgba(0,0,0,0.8)` | `rgba(255,255,255,0.9)` | `#2dd4bf` (teal-400) |
+| `--color-text-primary` | Headings, strong content | `#111827` (gray-900) | `#f3f4f6` (gray-100) | `#f3f4f6` |
+| `--color-text-secondary` | Body text | `#374151` (gray-700) | `#d1d5db` (gray-300) | `#d1d5db` |
+| `--color-text-tertiary` | Muted, metadata | `#6b7280` (gray-500) | `#9ca3af` (gray-400) | `#9ca3af` |
+| `--color-text-quaternary` | Disabled, placeholder | `#9ca3af` (gray-400) | `#6b7280` (gray-500) | `#6b7280` |
+| `--color-text-inverted` | Text on inverted bg | `#ffffff` | `#111827` | `#030712` |
+| `--color-text-accent` | Links, interactive elements | inherit | inherit | `#2dd4bf` (teal-400) |
+| `--color-border` | Standard borders | `#e5e7eb` (gray-200) | `#374151` (gray-700) | `#374151` |
+| `--color-border-strong` | Emphasis borders | `#d1d5db` (gray-300) | `#4b5563` (gray-600) | `#0d9488` (teal-600) |
+| `--color-icon-default` | Default icon color | `#6b7280` (gray-500) | `#9ca3af` (gray-400) | `#9ca3af` |
+| `--color-spinner` | Spinner animation | `rgba(0,0,0,0.85)` | `rgba(255,255,255,0.85)` | `#2dd4bf` |
+
+**Unchanged (not tokenized):** `text-amber-400` (stars), `text-sky-400` (Twitter), `text-red-600` (destructive) — these are semantic accent colors that stay constant across themes.
+
+### Tailwind Mapping
+
+```ts
+// tailwind.config.ts
+extend: {
+  colors: {
+    bg: "var(--color-bg)",
+    surface: "var(--color-bg-surface)",
+    "surface-hover": "var(--color-bg-surface-hover)",
+    "surface-active": "var(--color-bg-surface-active)",
+    "input-bg": "var(--color-bg-input)",
+    overlay: "var(--color-bg-overlay)",
+    skeleton: "var(--color-bg-skeleton)",
+    highlight: "var(--color-bg-highlight)",
+    inverted: "var(--color-bg-inverted)",
+    "text-primary": "var(--color-text-primary)",
+    "text-secondary": "var(--color-text-secondary)",
+    "text-tertiary": "var(--color-text-tertiary)",
+    "text-quaternary": "var(--color-text-quaternary)",
+    "text-inverted": "var(--color-text-inverted)",
+    "text-accent": "var(--color-text-accent)",
+    border: "var(--color-border)",
+    "border-strong": "var(--color-border-strong)",
+    "icon-default": "var(--color-icon-default)",
+    spinner: "var(--color-spinner)",
+  },
+}
+```
+
+Usage: `bg-surface` → `var(--color-bg-surface)`, `text-text-primary` → `var(--color-text-primary)`, `border-border` → `var(--color-border)`.
+
+## Implementation Phases
+
+### Phase 1: Foundation (infrastructure, no visual changes)
+
+**Files:**
+
+- `package.json` — install `next-themes`
+- `app/globals.css` — define CSS variable tokens for all 3 themes + remove hardcoded body background
+- `tailwind.config.ts` — add semantic color mappings via `extend.colors`
+- `app/layout.tsx` — add `suppressHydrationWarning` to `<html>`, configure viewport `themeColor` array
+- `app/providers.tsx` — add `ThemeProvider` from `next-themes` wrapping children
+
+**Steps:**
+
+1. `pnpm add next-themes`
+
+2. **`app/globals.css`** — Replace existing variables with theme-scoped tokens:
+   ```css
+   :root, [data-theme="light"] {
+     --color-bg: #ffffff;
+     --color-bg-surface: #f9fafb;
+     /* ... all light values ... */
+     color-scheme: light;
+   }
+   [data-theme="dark"] {
+     --color-bg: #030712;
+     --color-bg-surface: #111827;
+     /* ... all dark values ... */
+     color-scheme: dark;
+   }
+   [data-theme="teal"] {
+     --color-bg: #030712;
+     --color-bg-surface: #111827;
+     /* ... teal values with teal accents ... */
+     color-scheme: dark;
+   }
+   body {
+     background: var(--color-bg);
+     color: var(--color-text-primary);
+   }
+   ```
+   Remove the commented-out dark media query, old variable definitions, hardcoded `#ffffff` body background.
+   Replace global `button { @apply hover:bg-gray-50 }` with `button { @apply hover:bg-surface-hover }`.
+   Replace `.simple-bg` hardcoded gradient with variable-based version.
+
+3. **`tailwind.config.ts`** — Add `extend.colors` mapping tokens (as shown above). Do NOT add `darkMode` — not needed.
+
+4. **`app/layout.tsx`** — Add `suppressHydrationWarning` to `<html>`. Update viewport export:
+   ```ts
+   export const viewport: Viewport = {
+     themeColor: [
+       { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+       { media: "(prefers-color-scheme: dark)", color: "#030712" },
+     ],
+   };
+   ```
+
+5. **`app/providers.tsx`** — Wrap with `ThemeProvider`:
+   ```tsx
+   import { ThemeProvider } from "next-themes";
+
+   // Inside Providers component:
+   <ClerkProvider appearance={clerkAppearance}>
+     <ThemeProvider attribute="data-theme" defaultTheme="system" disableTransitionOnChange>
+       <SWRConfig ...>
+         <GlobalsProvider>
+           {children}
+         </GlobalsProvider>
+       </SWRConfig>
+     </ThemeProvider>
+   </ClerkProvider>
+   ```
+   Also synchronize Clerk appearance with the active theme. `ClerkProvider` wraps `ThemeProvider` (Clerk doesn't need to know about themes; instead, a `useTheme()` hook inside the provider tree reads the theme and applies `appearance` via a wrapper).
+
+   Actually, since `ClerkProvider` takes `appearance` as a prop and `useTheme()` must be called inside `ThemeProvider`, create a small wrapper:
+   ```tsx
+   function ClerkWithTheme({ children }) {
+     const { resolvedTheme } = useTheme();
+     const isDark = resolvedTheme === "dark" || resolvedTheme === "teal";
+     return (
+       <ClerkProvider appearance={isDark ? { baseTheme: dark } : undefined}>
+         {children}
+       </ClerkProvider>
+     );
+   }
+   ```
+   **Note:** This requires `ThemeProvider` to wrap `ClerkProvider`, which inverts the current nesting. Verify Clerk functions correctly inside `ThemeProvider`.
+
+### Phase 2: Migrate UI Primitives (shadcn components)
+
+**Files** (already reference undefined CSS variable tokens — this phase **fixes** them):
+
+- `app/components/ui/button.tsx` — verify `bg-primary`, `bg-secondary` etc. resolve to new tokens
+- `app/components/ui/input.tsx` — `border-input`, `ring-ring`, etc.
+- `app/components/ui/textarea.tsx` — same as input
+- `app/components/ui/dialog.tsx` — `bg-white` overlay + content
+- `app/components/ui/context-menu.tsx` — `bg-white` menu + focus states
+- `app/components/ui/skeleton.tsx` — `bg-gray-100` → `bg-skeleton`
+
+**Strategy:** These components already use shadcn token names (`bg-background`, `text-foreground`, `bg-primary`, etc.). Define these shadcn tokens as aliases in `globals.css` pointing to our semantic tokens:
+```css
+:root, [data-theme="light"] {
+  /* Shadcn compatibility aliases */
+  --background: var(--color-bg);
+  --foreground: var(--color-text-primary);
+  --primary: var(--color-bg-inverted);
+  --primary-foreground: var(--color-text-inverted);
+  --secondary: var(--color-bg-surface);
+  --secondary-foreground: var(--color-text-primary);
+  --muted: var(--color-bg-surface);
+  --muted-foreground: var(--color-text-tertiary);
+  --accent: var(--color-bg-surface-hover);
+  --accent-foreground: var(--color-text-primary);
+  --popover: var(--color-bg);
+  --popover-foreground: var(--color-text-primary);
+  --border: var(--color-border);
+  --input: var(--color-border);
+  --ring: var(--color-border-strong);
+  --destructive: #ef4444;
+  --destructive-foreground: #ffffff;
+}
+```
+Then add the corresponding `hsl()` or direct color utility mapping to Tailwind. This fixes the existing broken shadcn components AND themes them simultaneously.
+
+### Phase 3: Migrate Application Components
+
+**Files ranked by color density (migrate in this order):**
+
+| # | File | What changes |
+|---|------|-------------|
+| 1 | `app/globals.css` | Already done in Phase 1 |
+| 2 | `app/settings/page.tsx` (22 refs) | `text-gray-900` → `text-text-primary`, `text-gray-500` → `text-text-tertiary`, `bg-gray-50` → `bg-surface`, `border-dashed` border color, etc. |
+| 3 | `app/page.tsx` (23 refs) | Landing page: SVG grid pattern colors, feature cards, CTA button, browser mockup, self-host section |
+| 4 | `app/components/sidebar.tsx` (8 refs) | `bg-white` → `bg-bg`, active/inactive link colors, section header text |
+| 5 | `app/privacy/page.tsx` (7 refs) | Text and heading colors |
+| 6 | `app/components/result-item.tsx` (5 refs) | Card colors, hover states |
+| 7 | `app/components/header.tsx` (5 refs) | `bg-white` buttons → `bg-bg`, text colors |
+| 8 | `app/components/main-results.tsx` (4 refs) | Load More button, empty states |
+| 9 | `app/components/ui/context-menu.tsx` (4 refs) | Done in Phase 2 |
+| 10 | `app/components/go-back-navigation.tsx` (3 refs) | Inverted button bg, spinner color |
+| 11 | `app/components/new-item-dialog.tsx` (3 refs) | `bg-white` → `bg-bg`, submit button |
+| 12 | `app/components/editable-text.tsx` (2 refs) | `bg-gray-50`, `hover:bg-gray-200` |
+| 13 | `app/components/footer.tsx` (2 refs) | `bg-gray-100/60`, text colors |
+| 14 | `app/components/new-list-dialog.tsx` (2 refs) | `bg-white`, submit button |
+| 15 | `app/components/edit-item-dialog.tsx` (2 refs) | `bg-white`, submit button |
+| 16 | `app/components/search-bar.tsx` (1 ref) | `bg-black/5` → `bg-input-bg` |
+| 17 | `app/components/list-results.tsx` (1 ref) | Border/text color |
+| 18 | `app/components/highlight-chars.tsx` (1 ref) | `bg-slate-200` → `bg-highlight` |
+| 19 | `app/hooks/use-clipboard-url.tsx` (1 ref) | `!text-gray-400` in toast |
+| 20 | `app/components/icon-spinner.tsx` | Respect `--color-spinner` instead of hardcoded rgba |
+
+**Migration pattern** (example — sidebar.tsx):
+```
+bg-white         → bg-bg
+text-gray-500    → text-text-tertiary
+text-gray-600    → text-text-secondary
+text-gray-900    → text-text-primary
+bg-gray-100      → bg-surface-active
+bg-gray-50       → bg-surface
+hover:bg-gray-50 → hover:bg-surface-hover
+hover:text-gray-900 → hover:text-text-primary
+```
+
+### Phase 4: Theme Picker + Sonner
+
+**Files:**
+
+- `app/settings/page.tsx` — add theme picker section
+- `app/layout.tsx` or `app/providers.tsx` — wire Sonner `theme` prop
+
+**Theme picker design** (matches existing settings section pattern):
+```tsx
+<div className="flex items-start justify-between">
+  <div>
+    <h2 className="text-sm font-medium text-text-primary">Appearance</h2>
+    <p className="mt-1 text-xs text-text-tertiary">Choose your preferred theme</p>
+  </div>
+</div>
+<div className="flex flex-col gap-3 rounded-md border border-dashed p-4">
+  {/* 4 radio-style options: System, Light, Dark, Teal */}
+  {/* Each shows name + brief description */}
+  {/* Active option highlighted */}
+</div>
+```
+
+Place **before** the API Tokens section (top of settings content, most discoverable).
+
+**Sonner:** Create a small wrapper or read `useTheme()` to pass `theme={resolvedTheme === 'light' ? 'light' : 'dark'}` to `<Toaster>`.
+
+### Phase 5: Polish & Verification
+
+- Visually test all 3 themes across all routes (`/`, `/home`, `/settings`, `/sign-in`, `/privacy`, `/lists/[id]`)
+- Verify SSR: no flash of wrong theme on hard refresh
+- Verify system preference: toggle OS dark mode, confirm app follows when set to "System"
+- Verify persistence: select Teal, refresh page, confirm Teal persists
+- Verify Clerk: sign-in/sign-up forms match active theme
+- Verify Sonner: trigger a toast in each theme
+- Check `color-scheme` is set correctly (scrollbars, form controls adapt)
+- Quick contrast check: ensure `text-tertiary` on dark bg passes WCAG AA (4.5:1 minimum)
+
+## Acceptance Criteria
+
+- [ ] Three themes work: Light, Dark, Teal
+- [ ] System preference detected on first visit (light OS → light, dark OS → dark)
+- [ ] Manual override persists across page navigation and refresh
+- [ ] "System" option available to revert to automatic detection
+- [ ] Theme picker on settings page with 4 options
+- [ ] No flash of wrong theme on SSR/page load
+- [ ] All components themed: sidebar, header, search bar, result items, dialogs, context menus, footer, landing page
+- [ ] Clerk auth UI matches active theme
+- [ ] Sonner toasts match active theme
+- [ ] Browser chrome (`themeColor`) adapts to light/dark
+- [ ] Scrollbars and native controls follow `color-scheme`
+- [ ] Teal theme: teal accent on links, active states, borders; dark background
+- [ ] Existing accent colors preserved (amber stars, sky Twitter, red destructive)
+
+## Dependencies & Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| `ViewTransitions` + `ThemeProvider` conflict | Test early in Phase 1; `ThemeProvider` wraps body content, not `<html>` |
+| Clerk `appearance` sync requires nesting change | Invert `ClerkProvider`/`ThemeProvider` nesting; verify auth still works |
+| Missing a hardcoded color class | Grep audit of all `gray-`, `bg-white`, `bg-black`, `#fff`, `#000` before marking complete |
+| Landing page SVG patterns in dark mode | Replace `stroke-gray-200` / `fill-gray-50` with CSS variable-based fills |
+| Global `button hover:bg-gray-50` rule | Replace in Phase 1 to prevent dark mode flash |
+
+## Out of Scope
+
+- iOS Safari extension theming (extension already follows OS via `color-scheme: light dark`)
+- Server-side theme persistence / cross-device sync
+- Theme transition animations
+- Custom user-defined themes
+- E2E tests for theme (can be added later)
+
+## References
+
+- Brainstorm: `docs/brainstorms/2026-02-16-theme-support-brainstorm.md`
+- Settings page (picker location): `app/settings/page.tsx`
+- Layout (provider tree): `app/layout.tsx`
+- Providers: `app/providers.tsx`
+- Globals CSS: `app/globals.css`
+- Tailwind config: `tailwind.config.ts`
+- `next-themes` docs: https://github.com/pacocoursey/next-themes

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@clerk/clerk-react": "^5.1.0",
     "@clerk/nextjs": "^5.0.12",
+    "@clerk/themes": "^2.4.52",
     "@mozilla/readability": "^0.5.0",
     "@piotr-cz/swr-idb-cache": "^1.0.3",
     "@prisma/client": "^5.14.0",
@@ -46,6 +47,7 @@
     "framer-motion": "^11.1.9",
     "lucide-react": "^0.376.0",
     "next": "14.2.3",
+    "next-themes": "^0.4.6",
     "next-view-transitions": "^0.1.1",
     "node-fetch": "^3.3.2",
     "node-html-parser": "^6.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   '@clerk/nextjs':
     specifier: ^5.0.12
     version: 5.0.12(next@14.2.3)(react-dom@18.3.1)(react@18.3.1)
+  '@clerk/themes':
+    specifier: ^2.4.52
+    version: 2.4.52(react-dom@18.3.1)(react@18.3.1)
   '@mozilla/readability':
     specifier: ^0.5.0
     version: 0.5.0
@@ -59,6 +62,9 @@ dependencies:
   next:
     specifier: 14.2.3
     version: 14.2.3(@playwright/test@1.58.2)(react-dom@18.3.1)(react@18.3.1)
+  next-themes:
+    specifier: ^0.4.6
+    version: 0.4.6(react-dom@18.3.1)(react@18.3.1)
   next-view-transitions:
     specifier: ^0.1.1
     version: 0.1.1(next@14.2.3)(react-dom@18.3.1)(react@18.3.1)
@@ -305,7 +311,6 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       std-env: 3.10.0
       swr: 2.3.4(react@18.3.1)
-    dev: true
 
   /@clerk/testing@1.13.36(@playwright/test@1.58.2)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-daVeCM9xsbssT2DpgF4pDljm1VmZex4C8OfU8emudItoAralkNQzRdrh7NiW60Ad1B95gHCCJuMYUuaegL48yQ==}
@@ -328,6 +333,17 @@ packages:
       - react
       - react-dom
     dev: true
+
+  /@clerk/themes@2.4.52(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-27UWgn+QKnUE02yu9MZ6UgTYg7k5y7qig76WFwIviVEFxXYLk0o4ttqvDjvJKTfe2UMCkZLUmyglqGErlvvPzQ==}
+    engines: {node: '>=18.17.0'}
+    dependencies:
+      '@clerk/shared': 3.45.0(react-dom@18.3.1)(react@18.3.1)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+    dev: false
 
   /@clerk/types@4.101.15(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-Tb9FYlBQcUkyeX4ILMpNPzvZPwokk/gsDlWOayV+PQKcWvhWD2+xZYrXGv4eaxqIcbXLAMaUo8Gal+lVjQFDeg==}
@@ -2595,7 +2611,6 @@ packages:
   /dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-    dev: true
 
   /detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
@@ -3875,7 +3890,6 @@ packages:
   /js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
-    dev: true
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4140,6 +4154,16 @@ packages:
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
+
+  /next-themes@0.4.6(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
 
   /next-view-transitions@0.1.1(next@14.2.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-1rpXhWF8j0VJwJG52c8WeeAYpr1K7o3ub82lahbSoUwAry54TEm1d3mqBbSLLIMl85c3OewkZjxncTHwYFk+IA==}
@@ -5079,7 +5103,6 @@ packages:
 
   /std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-    dev: true
 
   /std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
@@ -5274,7 +5297,6 @@ packages:
       dequal: 2.0.3
       react: 18.3.1
       use-sync-external-store: 1.6.0(react@18.3.1)
-    dev: true
 
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -5452,7 +5474,6 @@ packages:
 
   /tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-    dev: true
 
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -5615,7 +5636,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     dependencies:
       react: 18.3.1
-    dev: true
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,10 +8,71 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        /* Semantic background tokens */
+        bg: "var(--color-bg)",
+        surface: "var(--color-bg-surface)",
+        "surface-hover": "var(--color-bg-surface-hover)",
+        "surface-active": "var(--color-bg-surface-active)",
+        "input-bg": "var(--color-bg-input)",
+        overlay: "var(--color-bg-overlay)",
+        skeleton: "var(--color-bg-skeleton)",
+        highlight: "var(--color-bg-highlight)",
+        inverted: "var(--color-bg-inverted)",
+
+        /* Semantic text tokens */
+        "text-primary": "var(--color-text-primary)",
+        "text-secondary": "var(--color-text-secondary)",
+        "text-tertiary": "var(--color-text-tertiary)",
+        "text-quaternary": "var(--color-text-quaternary)",
+        "text-inverted": "var(--color-text-inverted)",
+        "text-accent": "var(--color-text-accent)",
+
+        /* Semantic border tokens */
+        border: "var(--color-border)",
+        "border-strong": "var(--color-border-strong)",
+
+        /* Semantic icon/spinner tokens */
+        "icon-default": "var(--color-icon-default)",
+        spinner: "var(--color-spinner)",
+
+        /* Shadcn compatibility tokens */
+        background: "var(--background)",
+        foreground: "var(--foreground)",
+        primary: {
+          DEFAULT: "var(--primary)",
+          foreground: "var(--primary-foreground)",
+        },
+        secondary: {
+          DEFAULT: "var(--secondary)",
+          foreground: "var(--secondary-foreground)",
+        },
+        destructive: {
+          DEFAULT: "var(--destructive)",
+          foreground: "var(--destructive-foreground)",
+        },
+        muted: {
+          DEFAULT: "var(--muted)",
+          foreground: "var(--muted-foreground)",
+        },
+        accent: {
+          DEFAULT: "var(--accent)",
+          foreground: "var(--accent-foreground)",
+        },
+        popover: {
+          DEFAULT: "var(--popover)",
+          foreground: "var(--popover-foreground)",
+        },
+        input: "var(--input)",
+        ring: "var(--ring)",
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic":
           "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+      },
+      borderColor: {
+        DEFAULT: "var(--color-border)",
       },
     },
   },


### PR DESCRIPTION
## Summary
- Adds three themes: **Light** (existing), **Dark** (gray-950 bg), and **Teal** (dark bg with teal accents)
- Replaces all hardcoded gray/white Tailwind classes across 23 files with semantic CSS variable tokens
- Uses `next-themes` for system preference detection, `localStorage` persistence, and SSR flash prevention
- Theme picker on the settings page (System / Light / Dark / Teal)
- Clerk auth UI and Sonner toasts sync with the active theme

## How it works
- **`globals.css`**: Defines 19 semantic color tokens per theme via `[data-theme]` selectors, plus shadcn compatibility aliases
- **`tailwind.config.ts`**: Maps CSS variables to Tailwind color names (`bg-bg`, `text-text-primary`, `bg-surface`, etc.)
- **`providers.tsx`**: `ThemeProvider` wraps the app; `ClerkWithTheme` wrapper passes dark appearance to Clerk when in dark/teal mode
- **`themed-toaster.tsx`**: Syncs Sonner toast theme with resolved theme

## Test plan
- [x] `pnpm build` passes (all pages compile)
- [x] All 56 unit tests pass
- [x] Grep audit confirms no remaining hardcoded color references
- [ ] Visual check: Light theme matches current production
- [ ] Visual check: Dark theme — all text readable, no white flashes
- [ ] Visual check: Teal theme — teal accents visible on dark bg
- [ ] System preference toggle works
- [ ] Theme persists across page reloads
- [ ] Landing page (`/`) themes correctly
- [ ] Settings page theme picker highlights active choice

🤖 Generated with [Claude Code](https://claude.com/claude-code)