### PR TITLE
feat: add keyboard shortcut to Chrome extension

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -27,6 +27,13 @@ chrome.action.onClicked.addListener((tab) => {
   saveUrl(tab.id, tab.url);
 });
 
+// 2b. Keyboard shortcut (Cmd+Shift+C / Ctrl+Shift+C)
+chrome.commands.onCommand.addListener((command, tab) => {
+  if (command === "save-to-coolection" && tab?.id != null) {
+    saveUrl(tab.id, tab.url);
+  }
+});
+
 // 3. Context menu click — MUST be at top level
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === "add-to-coolection" && tab?.id != null) {

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -28,6 +28,15 @@
       "run_at": "document_idle"
     }
   ],
+  "commands": {
+    "save-to-coolection": {
+      "suggested_key": {
+        "default": "Alt+Shift+C",
+        "mac": "MacCtrl+Shift+C"
+      },
+      "description": "Save current page to Coolection"
+    }
+  },
   "icons": {
     "16": "icons/icon-16.png",
     "48": "icons/icon-48.png",


### PR DESCRIPTION
## Summary
- Adds `Ctrl+Shift+C` (Mac) / `Alt+Shift+C` (Windows/Linux) keyboard shortcut to save the current page
- Same behavior as clicking the toolbar icon — shows toast feedback
- Users can remap at `chrome://extensions/shortcuts`

## Changes
- `manifest.json`: added `commands` section with suggested key bindings
- `background.js`: added `chrome.commands.onCommand` listener that calls existing `saveUrl()`

## Test plan
- [x] Shortcut saves current page and shows toast
- [ ] Remapping at `chrome://extensions/shortcuts` works
- [ ] No conflict with built-in Chrome shortcuts

🤖 Generated with [Claude Code](https://claude.com/claude-code)