### PR TITLE
fix(categorization): retroactively categorize items when lists are created or renamed

### DIFF
--- a/app/api/list/create/route.ts
+++ b/app/api/list/create/route.ts
@@ -2,6 +2,7 @@
 
 import { NextResponse } from "next/server";
 
+import { categorizeExistingItems } from "@/lib/auto-categorize";
 import { embedList } from "@/lib/embed-and-store";
 import prisma from "@/lib/prisma";
 import { resolveUserId } from "@/lib/resolve-user-id";
@@ -50,8 +51,13 @@ export async function POST(req: Request) {
       },
     });
 
-    // Fire-and-forget: embed list for auto-categorization
-    embedList(createdList.id, createdList.name, createdList.description).catch(console.error);
+    // Embed list and retroactively categorize matching items
+    try {
+      const embedding = await embedList(createdList.id, createdList.name, createdList.description);
+      await categorizeExistingItems(createdList.id, embedding, userId);
+    } catch (e) {
+      console.error("Failed to embed/categorize list:", e);
+    }
 
     return NextResponse.json(
       {

--- a/app/api/list/edit/route.ts
+++ b/app/api/list/edit/route.ts
@@ -2,6 +2,7 @@
 
 import { NextResponse } from "next/server";
 
+import { categorizeExistingItems } from "@/lib/auto-categorize";
 import { embedList } from "@/lib/embed-and-store";
 import prisma from "@/lib/prisma";
 import { resolveUserId } from "@/lib/resolve-user-id";
@@ -27,8 +28,13 @@ export async function PATCH(req: Request) {
       },
     });
 
-    // Fire-and-forget: re-embed list with updated name
-    embedList(newListName.id, newListName.name, newListName.description).catch(console.error);
+    // Re-embed list and retroactively categorize matching items
+    try {
+      const embedding = await embedList(newListName.id, newListName.name, newListName.description);
+      await categorizeExistingItems(newListName.id, embedding, userId);
+    } catch (e) {
+      console.error("Failed to embed/categorize list:", e);
+    }
 
     return NextResponse.json(
       { message: `List ${newListName.name} name updated successfully` },

--- a/lib/auto-categorize.ts
+++ b/lib/auto-categorize.ts
@@ -53,3 +53,42 @@ export async function autoCategorize(
 
   return matches.map((m) => m.id);
 }
+
+const MAX_ITEMS_PER_LIST = 100;
+
+/**
+ * Retroactively categorize existing items into a newly created/updated list.
+ * Finds items whose embeddings are similar to the list embedding and assigns them.
+ */
+export async function categorizeExistingItems(
+  listId: string,
+  listEmbedding: number[],
+  userId: string,
+): Promise<number> {
+  const embeddingStr = JSON.stringify(listEmbedding);
+
+  const matchingItems = await prisma.$queryRaw<{ id: string; title: string; similarity: number }[]>`
+    SELECT i.id, i.title, 1 - (i.embedding <=> ${embeddingStr}::vector) AS similarity
+    FROM item i
+    WHERE i."userId" = ${userId}
+      AND i."isDeleted" = false
+      AND i.embedding IS NOT NULL
+      AND i.id NOT IN (SELECT il."itemId" FROM item_list il WHERE il."listId" = ${listId})
+      AND 1 - (i.embedding <=> ${embeddingStr}::vector) > ${SIMILARITY_THRESHOLD}
+    ORDER BY similarity DESC
+    LIMIT ${MAX_ITEMS_PER_LIST};
+  `;
+
+  if (matchingItems.length === 0) return 0;
+
+  await prisma.itemList.createMany({
+    data: matchingItems.map((item) => ({ itemId: item.id, listId })),
+    skipDuplicates: true,
+  });
+
+  console.log(
+    `Retroactively categorized ${matchingItems.length} items into list ${listId}: ${matchingItems.map((i) => `${i.title} (${i.similarity.toFixed(2)})`).join(", ")}`,
+  );
+
+  return matchingItems.length;
+}


### PR DESCRIPTION
## Summary
- Adds `categorizeExistingItems()` to find and assign existing items to a newly created or renamed list based on embedding similarity
- List create and edit routes now `await` embedding + categorization (instead of fire-and-forget) for Vercel compatibility
- Fixes issue where previously saved items wouldn't appear in a newly created list

## Test Coverage
All new code paths are database-bound (pgvector raw SQL). Existing unit tests pass (62/62).

## Pre-Landing Review
No issues found.

## Test plan
- [x] All Vitest tests pass (62 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)